### PR TITLE
Complete Windows native setup and release closure

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -296,9 +296,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc 0.2.189",
 ]

--- a/engine/bins/legion-hook/src/main.rs
+++ b/engine/bins/legion-hook/src/main.rs
@@ -1,31 +1,547 @@
 #![forbid(unsafe_code)]
 
-use std::io::{self, Read, Write};
+use std::{
+    fs,
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+};
+
+use legion_application::{NativeApplication, NativeApplicationConfig};
+use legion_contracts::{AgentId, EffectClass, EffectRequest, RequestId, TaskId};
+use serde_json::{Map, Value};
+
 mod error;
 mod protocol;
 
 use error::HookError;
 use protocol::{HookRequest, HookResponse};
 
-/// Translate a versioned host frame into an explicit fidelity result. This
-/// binary deliberately does not inspect tool names, classify effects, load
-/// policy, or synthesize a decision: those are Legion-core responsibilities.
+/// Translate one versioned host frame into an explicit, strongly enforced
+/// decision. Lifecycle/post-effect observations are safe to acknowledge;
+/// pre-effect frames must carry enough typed identity to reach native policy.
 pub fn dispatch(request: HookRequest) -> HookResponse {
     let event_type = request.event_type.clone();
     if let Err(error) = request.validate() {
         return response_for_error(event_type, error);
     }
-    HookResponse::unsupported(request.event_type)
+
+    if request.is_lifecycle() {
+        return HookResponse::allowed(request.event_type, "lifecycle observation accepted");
+    }
+    if request.is_post_effect() {
+        return HookResponse::allowed(request.event_type, "post-effect observation accepted");
+    }
+    if !request.is_pre_effect() {
+        return HookResponse::denied(
+            request.event_type,
+            "ARC_HOST_EVENT_INVALID",
+            "unsupported hook event",
+            "strong",
+        );
+    }
+
+    if is_destructive_command(&request.payload) {
+        return HookResponse::denied(
+            request.event_type,
+            "ARC_EFFECT_CLASS_UNAUTHORIZED",
+            "destructive command class is blocked; use a bounded, reversible alternative",
+            "strong",
+        );
+    }
+    if rewrite_push_requires_approval(&request.payload) {
+        return HookResponse::denied(
+            request.event_type,
+            "ARC_APPROVAL_REQUIRED",
+            "git push rewrites published history and needs a target-bound approval",
+            "strong",
+        );
+    }
+
+    let effect = match effect_request(&request) {
+        Ok(effect) => effect,
+        Err(message) => {
+            return HookResponse::denied(
+                request.event_type,
+                "ARC_HOST_EVENT_INVALID",
+                message,
+                "strong",
+            )
+        }
+    };
+
+    let application = match native_application() {
+        Ok(application) => application,
+        Err(_) => {
+            return HookResponse::denied(
+                request.event_type,
+                "ARC_NATIVE_POLICY_UNAVAILABLE",
+                "native policy configuration is unavailable",
+                "strong",
+            )
+        }
+    };
+
+    authorize_effect(request.event_type, &effect, application.as_ref())
+}
+
+fn authorize_effect(
+    event_type: String,
+    effect: &EffectRequest,
+    application: Option<&NativeApplication>,
+) -> HookResponse {
+    match application {
+        Some(application) => match application.authorize_hook(effect) {
+            Ok(()) => HookResponse::allowed(event_type, "authorized"),
+            Err(_) => HookResponse::denied(
+                event_type,
+                "ARC_POLICY_DENIED",
+                "native policy denied effect",
+                "strong",
+            ),
+        },
+        // Hook stdin has no prompt, contract, or policy context. Hard gates
+        // already ran in dispatch; absent explicit native policy, ambient
+        // authority supplies the remaining decision.
+        None => HookResponse::allowed(event_type, "ambient effect accepted"),
+    }
 }
 
 fn response_for_error(event_type: String, error: HookError) -> HookResponse {
-    let health = match error {
+    if matches!(&error, HookError::InvalidRequest(message) if message == "event type is unsupported")
+    {
+        return HookResponse::denied(
+            event_type,
+            "ARC_HOST_EVENT_INVALID",
+            "unsupported hook event",
+            "strong",
+        );
+    }
+    let health = match &error {
         HookError::InvalidRequest(_)
         | HookError::MalformedInput(_)
         | HookError::UnsupportedVersion(_) => "strong",
         HookError::Io(_) | HookError::Serialization(_) => "unsupported",
     };
     HookResponse::denied(event_type, error.code(), error.public_message(), health)
+}
+
+fn native_application() -> Result<Option<NativeApplication>, String> {
+    let source = match std::env::var("LEGION_NATIVE_APPLICATION_CONFIG") {
+        Ok(source) => source,
+        Err(std::env::VarError::NotPresent) => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+    if source.trim().is_empty() {
+        return Err("native application configuration is empty".into());
+    }
+    NativeApplicationConfig::from_versioned_source(&source)
+        .and_then(NativeApplicationConfig::build)
+        .map(Some)
+        .map_err(|error| error.to_string())
+}
+
+fn effect_request(request: &HookRequest) -> Result<EffectRequest, String> {
+    let payload = request
+        .payload
+        .as_object()
+        .ok_or_else(|| "request payload must be a JSON object".to_owned())?;
+    let source = payload
+        .get("effectRequest")
+        .or_else(|| payload.get("effect_request"))
+        .and_then(Value::as_object)
+        .unwrap_or(payload);
+    let effect = source
+        .get("effect")
+        .and_then(Value::as_object)
+        .unwrap_or(source);
+    let tool_name = first_string(source, &["toolName", "tool_name"])
+        .or_else(|| first_string(payload, &["toolName", "tool_name"]));
+    let command = command_value(source).or_else(|| command_value(payload));
+    let class_name = first_string(effect, &["effectClass", "effect_class"])
+        .or_else(|| first_string(source, &["effectClass", "effect_class"]))
+        .or_else(|| first_string(payload, &["effectClass", "effect_class"]));
+    let effect_class = parse_effect_class(
+        class_name.as_deref(),
+        tool_name.as_deref(),
+        command.as_deref(),
+    )
+    .ok_or_else(|| "effect class is missing or unsupported".to_owned())?;
+
+    let tool_input = source
+        .get("tool_input")
+        .or_else(|| source.get("toolInput"))
+        .or_else(|| payload.get("tool_input"))
+        .or_else(|| payload.get("toolInput"))
+        .and_then(Value::as_object);
+    let target = first_string(effect, &["target"])
+        .or_else(|| first_string(source, &["target"]))
+        .or_else(|| first_string(payload, &["target"]))
+        .or_else(|| {
+            tool_input.and_then(|input| first_string(input, &["file_path", "path", "url", "query"]))
+        })
+        .or_else(|| command.clone())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| "effect target is missing".to_owned())?;
+    let operation = first_string(effect, &["operation"])
+        .or_else(|| first_string(source, &["operation"]))
+        .or_else(|| first_string(payload, &["operation"]))
+        .or_else(|| tool_name.clone())
+        .or_else(|| Some(default_operation(effect_class).to_owned()))
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| "effect operation is missing".to_owned())?;
+
+    let source_revision = first_string(source, &["sourceRevision", "source_revision"])
+        .or_else(|| first_string(payload, &["sourceRevision", "source_revision"]))
+        .or_else(|| {
+            std::env::var("LEGION_SOURCE_REVISION")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .or_else(|| resolve_source_revision(payload))
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| "source revision is missing".to_owned())?;
+
+    let request_id = typed_id(
+        first_string(source, &["requestId", "request_id"]).or_else(|| {
+            first_string(
+                payload,
+                &[
+                    "requestId",
+                    "request_id",
+                    "tool_use_id",
+                    "toolUseId",
+                    "eventId",
+                    "event_id",
+                ],
+            )
+        }),
+        "native-hook-request",
+        RequestId::new,
+    )?;
+    let task_id = typed_id(
+        first_string(source, &["taskId", "task_id"])
+            .or_else(|| first_string(payload, &["taskId", "task_id"])),
+        "native-hook-task",
+        TaskId::new,
+    )?;
+    let requested_by = typed_id(
+        first_string(
+            source,
+            &["requestedBy", "requested_by", "agentId", "agent_id"],
+        )
+        .or_else(|| {
+            first_string(
+                payload,
+                &["requestedBy", "requested_by", "agentId", "agent_id"],
+            )
+        }),
+        "native-hook",
+        AgentId::new,
+    )?;
+    let mut approval_required = first_bool(source, &["approvalRequired", "approval_required"])
+        .or_else(|| first_bool(payload, &["approvalRequired", "approval_required"]))
+        .unwrap_or(false);
+    if matches!(effect_class, EffectClass::VCS_PUSH) && command_has_rewrite_flag(command.as_deref())
+    {
+        // Rewrite approvals must be explicit and target-bound. This adapter
+        // has no approval store, so never turn one into an implicit allow.
+        approval_required = true;
+    }
+
+    let preview = first_string(effect, &["preview"])
+        .or_else(|| first_string(source, &["preview"]))
+        .or_else(|| first_string(payload, &["preview"]));
+    let effect = EffectRequest {
+        schema_version: 1,
+        request_id,
+        task_id,
+        requested_by,
+        effect_class,
+        target,
+        operation,
+        preview,
+        source_revision,
+        approval_required,
+    };
+    effect
+        .validate()
+        .map_err(|error| format!("invalid effect request: {error}"))?;
+    Ok(effect)
+}
+
+fn typed_id<T>(
+    value: Option<String>,
+    fallback: &str,
+    constructor: fn(String) -> Result<T, legion_contracts::ContractError>,
+) -> Result<T, String> {
+    constructor(value.unwrap_or_else(|| fallback.to_owned()))
+        .map_err(|error| format!("invalid hook identity: {error}"))
+}
+
+fn first_string(object: &Map<String, Value>, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| object.get(*key).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn first_bool(object: &Map<String, Value>, keys: &[&str]) -> Option<bool> {
+    keys.iter()
+        .find_map(|key| object.get(*key).and_then(Value::as_bool))
+}
+
+fn command_value(object: &Map<String, Value>) -> Option<String> {
+    first_string(object, &["command", "cmd"])
+        .or_else(|| {
+            object
+                .get("tool_input")
+                .or_else(|| object.get("toolInput"))
+                .and_then(Value::as_object)
+                .and_then(|input| first_string(input, &["command", "cmd"]))
+        })
+        .or_else(|| {
+            object
+                .get("effectRequest")
+                .or_else(|| object.get("effect_request"))
+                .and_then(Value::as_object)
+                .and_then(command_value)
+        })
+}
+
+fn parse_effect_class(
+    class_name: Option<&str>,
+    tool_name: Option<&str>,
+    command: Option<&str>,
+) -> Option<EffectClass> {
+    if let Some(class_name) = class_name {
+        let normalized = class_name
+            .trim()
+            .replace(&['-', ' ', '/'][..], "_")
+            .to_ascii_uppercase();
+        return match normalized.as_str() {
+            "FILE_WRITE" | "WRITE" => Some(EffectClass::FILE_WRITE),
+            "FILE_DELETE" | "DELETE" => Some(EffectClass::FILE_DELETE),
+            "FILE_MOVE" | "MOVE" => Some(EffectClass::FILE_MOVE),
+            "COMMAND_EXEC" | "EXECUTE" | "SHELL" => Some(EffectClass::COMMAND_EXEC),
+            "NETWORK_EGRESS" | "NETWORK" | "CONNECT" => Some(EffectClass::NETWORK_EGRESS),
+            "PROCESS_SPAWN" | "SPAWN" => Some(EffectClass::PROCESS_SPAWN),
+            "CREDENTIAL_ACCESS" | "CREDENTIALS" => Some(EffectClass::CREDENTIAL_ACCESS),
+            "DEPENDENCY_INSTALL" | "INSTALL" => Some(EffectClass::DEPENDENCY_INSTALL),
+            "VCS_COMMIT" | "COMMIT" => Some(EffectClass::VCS_COMMIT),
+            "VCS_PUSH" | "PUSH" => Some(EffectClass::VCS_PUSH),
+            "PUBLISH" => Some(EffectClass::PUBLISH),
+            _ => None,
+        };
+    }
+
+    let tool = tool_name.unwrap_or_default();
+    match tool {
+        "Write" | "Edit" | "NotebookEdit" => Some(EffectClass::FILE_WRITE),
+        "WebFetch" | "WebSearch" => Some(EffectClass::NETWORK_EGRESS),
+        "shell" | "shell_command" | "Bash" | "PowerShell" | "apply_patch" => {
+            Some(command_effect_class(command))
+        }
+        _ if command.is_some() => Some(command_effect_class(command)),
+        _ => None,
+    }
+}
+
+fn command_effect_class(command: Option<&str>) -> EffectClass {
+    let command = command.unwrap_or_default().trim().to_ascii_lowercase();
+    if contains_command_pair(&command, "git", "push") {
+        EffectClass::VCS_PUSH
+    } else if contains_command_pair(&command, "git", "commit") {
+        EffectClass::VCS_COMMIT
+    } else if contains_command_pair(&command, "npm", "install")
+        || contains_command_pair(&command, "npm", "ci")
+        || contains_command_pair(&command, "pnpm", "install")
+        || contains_command_pair(&command, "pnpm", "add")
+        || contains_command_pair(&command, "yarn", "install")
+        || contains_command_pair(&command, "yarn", "add")
+        || contains_command_pair(&command, "cargo", "install")
+        || contains_command_pair(&command, "cargo", "add")
+    {
+        EffectClass::DEPENDENCY_INSTALL
+    } else {
+        EffectClass::COMMAND_EXEC
+    }
+}
+
+fn contains_command_pair(command: &str, first: &str, second: &str) -> bool {
+    command
+        .split(|character| matches!(character, ';' | '&' | '|' | '\n'))
+        .any(|segment| {
+            let mut tokens = segment.split_whitespace();
+            while let Some(token) = tokens.next() {
+                if token == first && tokens.next() == Some(second) {
+                    return true;
+                }
+            }
+            false
+        })
+}
+
+fn default_operation(effect_class: EffectClass) -> &'static str {
+    match effect_class {
+        EffectClass::FILE_WRITE => "write",
+        EffectClass::FILE_DELETE => "delete",
+        EffectClass::FILE_MOVE => "move",
+        EffectClass::COMMAND_EXEC => "execute",
+        EffectClass::NETWORK_EGRESS => "connect",
+        EffectClass::PROCESS_SPAWN => "spawn",
+        EffectClass::CREDENTIAL_ACCESS => "access",
+        EffectClass::DEPENDENCY_INSTALL => "install",
+        EffectClass::VCS_COMMIT => "commit",
+        EffectClass::VCS_PUSH => "push",
+        EffectClass::PUBLISH => "publish",
+    }
+}
+
+fn command_has_rewrite_flag(command: Option<&str>) -> bool {
+    let command = command.unwrap_or_default().to_ascii_lowercase();
+    command.contains("--force")
+        || command.contains("--delete")
+        || command
+            .split_whitespace()
+            .any(|token| token == "-f" || token == "-d")
+}
+
+fn rewrite_push_requires_approval(payload: &Value) -> bool {
+    let Some(object) = payload.as_object() else {
+        return false;
+    };
+    let Some(command) = command_value(object) else {
+        return false;
+    };
+    let command = command.trim().to_ascii_lowercase();
+    contains_command_pair(&command, "git", "push") && command_has_rewrite_flag(Some(&command))
+}
+
+fn is_destructive_command(payload: &Value) -> bool {
+    let Some(object) = payload.as_object() else {
+        return false;
+    };
+    let Some(command) = command_value(object) else {
+        return false;
+    };
+    let command = command.to_ascii_lowercase();
+    let destructive_segment = |segment: &str| {
+        let segment = segment.trim_start();
+        if let Some(rest) = segment.strip_prefix("rm") {
+            let rest = rest.trim_start();
+            if rest.starts_with("--recursive") {
+                return true;
+            }
+            if let Some(option) = rest.split_whitespace().next() {
+                if option.starts_with('-') && option.contains('r') {
+                    return true;
+                }
+            }
+        }
+        (segment.starts_with("remove-item") && segment.contains("-recurse"))
+            || contains_command_pair(segment, "git", "clean")
+            || segment.starts_with("dropdb")
+            || contains_command_pair(segment, "terraform", "apply")
+            || contains_command_pair(segment, "terraform", "destroy")
+    };
+    command
+        .split(|character| matches!(character, ';' | '&' | '|'))
+        .any(destructive_segment)
+        || command
+            .split('|')
+            .collect::<Vec<_>>()
+            .windows(2)
+            .any(|parts| {
+                let left = parts[0].trim_start();
+                let is_curl = left.split_whitespace().any(|token| token == "curl");
+                is_curl && {
+                    let right = parts[1].trim_start();
+                    right.starts_with("sh") || right.starts_with("bash")
+                }
+            })
+}
+
+fn resolve_source_revision(payload: &Map<String, Value>) -> Option<String> {
+    let workspace = first_string(payload, &["cwd", "workspace"])
+        .map(PathBuf::from)
+        .or_else(|| std::env::current_dir().ok())?;
+    let git_dir = resolve_git_dir(&workspace)?;
+    let head = fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let head = head.trim();
+    if valid_revision(head) {
+        return Some(head.to_ascii_lowercase());
+    }
+    let reference = head.strip_prefix("ref: ")?.trim();
+    if !valid_git_reference(reference) {
+        return None;
+    }
+    let common_dir = resolve_common_git_dir(&git_dir).unwrap_or_else(|| git_dir.clone());
+    for root in [&git_dir, &common_dir] {
+        if let Ok(value) = fs::read_to_string(root.join(reference)) {
+            let value = value.trim();
+            if valid_revision(value) {
+                return Some(value.to_ascii_lowercase());
+            }
+        }
+    }
+    for root in [&git_dir, &common_dir] {
+        if let Some(value) = revision_from_packed_refs(root, reference) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn resolve_git_dir(workspace: &Path) -> Option<PathBuf> {
+    let marker = workspace.join(".git");
+    if marker.is_dir() {
+        return Some(marker);
+    }
+    let marker_text = fs::read_to_string(&marker).ok()?;
+    let relative = marker_text.trim().strip_prefix("gitdir: ")?.trim();
+    let candidate = PathBuf::from(relative);
+    Some(if candidate.is_absolute() {
+        candidate
+    } else {
+        workspace.join(candidate)
+    })
+}
+
+fn resolve_common_git_dir(git_dir: &Path) -> Option<PathBuf> {
+    let value = fs::read_to_string(git_dir.join("commondir")).ok()?;
+    let relative = PathBuf::from(value.trim());
+    Some(if relative.is_absolute() {
+        relative
+    } else {
+        git_dir.join(relative)
+    })
+}
+
+fn revision_from_packed_refs(git_dir: &Path, reference: &str) -> Option<String> {
+    let packed = fs::read_to_string(git_dir.join("packed-refs")).ok()?;
+    packed.lines().find_map(|line| {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with('^') {
+            return None;
+        }
+        let mut fields = line.split_whitespace();
+        let revision = fields.next()?;
+        let name = fields.next()?;
+        (name == reference && valid_revision(revision)).then(|| revision.to_ascii_lowercase())
+    })
+}
+
+fn valid_git_reference(reference: &str) -> bool {
+    !reference.is_empty()
+        && !Path::new(reference).is_absolute()
+        && reference
+            .split(['/', '\\'])
+            .all(|segment| !segment.is_empty() && segment != "." && segment != "..")
+}
+
+fn valid_revision(value: &str) -> bool {
+    matches!(value.len(), 40 | 64) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn read_request() -> Result<Vec<u8>, HookError> {
@@ -67,4 +583,140 @@ fn main() {
         Err(error) => error_response(error),
     };
     let _ = write_response(response);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn effect(effect_class: EffectClass) -> EffectRequest {
+        EffectRequest {
+            schema_version: 1,
+            request_id: RequestId::new("test-request").expect("valid test request id"),
+            task_id: TaskId::new("test-task").expect("valid test task id"),
+            requested_by: AgentId::new("test-agent").expect("valid test agent id"),
+            effect_class,
+            target: "test-target".into(),
+            operation: default_operation(effect_class).into(),
+            preview: None,
+            source_revision: "test-revision".into(),
+            approval_required: false,
+        }
+    }
+
+    fn pre_effect(command: &str) -> HookRequest {
+        HookRequest {
+            schema_version: protocol::SCHEMA_VERSION,
+            kind: protocol::REQUEST_KIND.into(),
+            event_type: "PreToolUse".into(),
+            payload: json!({
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+            }),
+        }
+    }
+
+    fn temporary_repository() -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "legion-hook-source-revision-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(root.join(".git/refs/heads")).expect("create test git directory");
+        root
+    }
+
+    #[test]
+    fn source_revision_reads_git_metadata_without_spawning() {
+        let root = temporary_repository();
+        let revision = "0123456789abcdef0123456789abcdef01234567";
+        fs::write(root.join(".git/HEAD"), "ref: refs/heads/main\n").expect("write HEAD");
+        fs::write(root.join(".git/refs/heads/main"), format!("{revision}\n"))
+            .expect("write loose ref");
+        let payload = json!({"cwd": root.to_string_lossy()});
+        assert_eq!(
+            resolve_source_revision(payload.as_object().expect("payload object")).as_deref(),
+            Some(revision)
+        );
+        fs::remove_dir_all(&root).expect("remove test repository");
+    }
+
+    #[test]
+    fn source_revision_reads_packed_refs_without_spawning() {
+        let root = temporary_repository();
+        let revision = "89abcdef0123456789abcdef0123456789abcdef";
+        fs::write(root.join(".git/HEAD"), "ref: refs/heads/main\n").expect("write HEAD");
+        fs::write(
+            root.join(".git/packed-refs"),
+            format!("# pack-refs with: peeled\n{revision} refs/heads/main\n"),
+        )
+        .expect("write packed refs");
+        let payload = json!({"workspace": root.to_string_lossy()});
+        assert_eq!(
+            resolve_source_revision(payload.as_object().expect("payload object")).as_deref(),
+            Some(revision)
+        );
+        fs::remove_dir_all(&root).expect("remove test repository");
+    }
+
+    #[test]
+    fn absent_policy_allows_every_effect_class() {
+        for effect_class in [
+            EffectClass::FILE_WRITE,
+            EffectClass::FILE_DELETE,
+            EffectClass::FILE_MOVE,
+            EffectClass::COMMAND_EXEC,
+            EffectClass::NETWORK_EGRESS,
+            EffectClass::PROCESS_SPAWN,
+            EffectClass::CREDENTIAL_ACCESS,
+            EffectClass::DEPENDENCY_INSTALL,
+            EffectClass::VCS_COMMIT,
+            EffectClass::VCS_PUSH,
+            EffectClass::PUBLISH,
+        ] {
+            let response = authorize_effect("PreToolUse".into(), &effect(effect_class), None);
+            assert!(response.allowed, "ambient effect denied: {effect_class:?}");
+            assert!(response.code.is_none());
+            assert_eq!(response.enforcement_health, "strong");
+        }
+    }
+
+    #[test]
+    fn hard_gates_precede_ambient_fallback() {
+        for (command, code) in [
+            (
+                "rm -rf /tmp/legion-hook-test",
+                "ARC_EFFECT_CLASS_UNAUTHORIZED",
+            ),
+            (
+                "echo ok; rm -fr /tmp/legion-hook-test",
+                "ARC_EFFECT_CLASS_UNAUTHORIZED",
+            ),
+            ("git push --force origin main", "ARC_APPROVAL_REQUIRED"),
+            ("git  push --delete origin main", "ARC_APPROVAL_REQUIRED"),
+        ] {
+            let response = dispatch(pre_effect(command));
+            assert!(!response.allowed, "hard gate allowed: {command}");
+            assert_eq!(response.code.as_deref(), Some(code));
+            assert_eq!(response.enforcement_health, "strong");
+        }
+    }
+
+    #[test]
+    fn unknown_event_dispatch_fails_closed() {
+        let response = dispatch(HookRequest {
+            schema_version: protocol::SCHEMA_VERSION,
+            kind: protocol::REQUEST_KIND.into(),
+            event_type: "unknown-event".into(),
+            payload: json!({}),
+        });
+        assert!(!response.allowed);
+        assert_eq!(response.code.as_deref(), Some("ARC_HOST_EVENT_INVALID"));
+        assert_eq!(response.enforcement_health, "strong");
+    }
 }

--- a/engine/bins/legion-hook/src/protocol.rs
+++ b/engine/bins/legion-hook/src/protocol.rs
@@ -4,6 +4,29 @@ pub const SCHEMA_VERSION: u32 = 1;
 pub const REQUEST_KIND: &str = "legion-hook-request";
 pub const RESPONSE_KIND: &str = "legion-hook-response";
 
+/// Host lifecycle names accepted by both retained Claude/Codex registrations
+/// & the canonical Arcane event vocabulary. Unknown names are rejected before
+/// any effect can be considered.
+pub const SUPPORTED_EVENT_TYPES: &[&str] = &[
+    "SessionStart",
+    "SubagentStart",
+    "UserPromptSubmit",
+    "PostCompact",
+    "PreToolUse",
+    "PostToolUse",
+    "PostToolUseFailure",
+    "Stop",
+    "session-start",
+    "subagent-start",
+    "user-prompt-submit",
+    "post-compact",
+    "pre-effect",
+    "post-effect",
+    "post-effect-failure",
+    "stop",
+    "ci-boundary",
+];
+
 #[derive(Clone, Debug)]
 pub struct HookRequest {
     pub schema_version: u32,
@@ -19,6 +42,18 @@ impl HookRequest {
         let object = value
             .as_object()
             .ok_or_else(|| crate::error::HookError::invalid("request must be a JSON object"))?;
+        if object.contains_key("payload")
+            && object.keys().any(|key| {
+                !matches!(
+                    key.as_str(),
+                    "schemaVersion" | "kind" | "eventType" | "hook_event_name" | "payload"
+                )
+            })
+        {
+            return Err(crate::error::HookError::invalid(
+                "request contains unknown frame fields",
+            ));
+        }
         // Native host hooks send an unwrapped event object.  Normalize that
         // transport shape to this adapter's versioned frame without assigning
         // any meaning to the event payload. Supplied malformed/overflowing
@@ -30,10 +65,25 @@ impl HookRequest {
                 .and_then(|value| u32::try_from(value).ok())
                 .unwrap_or(0),
         };
-        let kind = string(object, "kind").unwrap_or_else(|| REQUEST_KIND.into());
-        let event_type = string(object, "eventType")
-            .or_else(|| string(object, "hook_event_name"))
-            .unwrap_or_default();
+        let kind = match object.get("kind") {
+            None => REQUEST_KIND.into(),
+            Some(value) => value
+                .as_str()
+                .map(ToOwned::to_owned)
+                .ok_or_else(|| crate::error::HookError::invalid("request kind must be a string"))?,
+        };
+        let event_type = match (
+            string(object, "eventType"),
+            string(object, "hook_event_name"),
+        ) {
+            (Some(event_type), Some(hook_event_name)) if event_type != hook_event_name => {
+                return Err(crate::error::HookError::invalid(
+                    "event type fields disagree",
+                ));
+            }
+            (Some(event_type), _) | (_, Some(event_type)) => event_type,
+            (None, None) => String::new(),
+        };
         let payload = object
             .get("payload")
             .cloned()
@@ -60,7 +110,45 @@ impl HookRequest {
         if self.event_type.trim().is_empty() {
             return Err(crate::error::HookError::invalid("event type is required"));
         }
+        if !SUPPORTED_EVENT_TYPES.contains(&self.event_type.as_str()) {
+            return Err(crate::error::HookError::invalid(
+                "event type is unsupported",
+            ));
+        }
+        if !self.payload.is_object() {
+            return Err(crate::error::HookError::invalid(
+                "request payload must be a JSON object",
+            ));
+        }
         Ok(())
+    }
+
+    pub fn is_lifecycle(&self) -> bool {
+        matches!(
+            self.event_type.as_str(),
+            "SessionStart"
+                | "SubagentStart"
+                | "UserPromptSubmit"
+                | "PostCompact"
+                | "Stop"
+                | "session-start"
+                | "subagent-start"
+                | "user-prompt-submit"
+                | "post-compact"
+                | "stop"
+                | "ci-boundary"
+        )
+    }
+
+    pub fn is_pre_effect(&self) -> bool {
+        matches!(self.event_type.as_str(), "PreToolUse" | "pre-effect")
+    }
+
+    pub fn is_post_effect(&self) -> bool {
+        matches!(
+            self.event_type.as_str(),
+            "PostToolUse" | "PostToolUseFailure" | "post-effect" | "post-effect-failure"
+        )
     }
 }
 
@@ -81,10 +169,22 @@ impl HookResponse {
             schema_version: SCHEMA_VERSION,
             kind: RESPONSE_KIND,
             event_type: event_type.into(),
+            allowed: false,
+            code: Some("ARC_NATIVE_POLICY_UNAVAILABLE".into()),
+            reason: "native hook enforcement is unavailable; effect is refused".into(),
+            enforcement_health: "unsupported",
+        }
+    }
+
+    pub fn allowed(event_type: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            kind: RESPONSE_KIND,
+            event_type: event_type.into(),
             allowed: true,
             code: None,
-            reason: "native hook enforcement is not available through this adapter".into(),
-            enforcement_health: "unsupported",
+            reason: reason.into(),
+            enforcement_health: "strong",
         }
     }
 
@@ -120,6 +220,22 @@ impl HookResponse {
         object.insert("kind".into(), Value::String(self.kind.into()));
         object.insert("reason".into(), Value::String(self.reason.clone()));
         object.insert("schemaVersion".into(), Value::from(self.schema_version));
+
+        // Preserve native Claude/Codex blocking shapes alongside the typed
+        // response envelope. Hosts ignore these fields when an event cannot
+        // be blocked, while PreToolUse/Stop consume them directly.
+        if !self.allowed && matches!(self.event_type.as_str(), "PreToolUse" | "pre-effect") {
+            let mut specific = Map::new();
+            specific.insert("hookEventName".into(), Value::String("PreToolUse".into()));
+            specific.insert("permissionDecision".into(), Value::String("deny".into()));
+            specific.insert(
+                "permissionDecisionReason".into(),
+                Value::String(self.reason.clone()),
+            );
+            object.insert("hookSpecificOutput".into(), Value::Object(specific));
+        } else if !self.allowed && matches!(self.event_type.as_str(), "Stop" | "stop") {
+            object.insert("decision".into(), Value::String("block".into()));
+        }
         Value::Object(object)
     }
 }
@@ -129,4 +245,21 @@ fn string(object: &Map<String, Value>, key: &str) -> Option<String> {
         .get(key)
         .and_then(Value::as_str)
         .map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_string_frame_kind_is_rejected() {
+        assert!(HookRequest::parse(br#"{"kind":42,"eventType":"Stop","payload":{}}"#).is_err());
+    }
+
+    #[test]
+    fn unknown_event_is_rejected_by_validation() {
+        let request = HookRequest::parse(br#"{"eventType":"unknown","payload":{}}"#)
+            .expect("frame shape is valid");
+        assert!(request.validate().is_err());
+    }
 }

--- a/engine/bins/legion-mcp/src/main.rs
+++ b/engine/bins/legion-mcp/src/main.rs
@@ -13,7 +13,7 @@ async fn run_binary(application: Arc<NativeApplication>) -> std::io::Result<()> 
     // without a verified installed release identity.
     run_with_application(
         application,
-        Arc::new(RejectingBindingGate::new("legion setup --repair")),
+        Arc::new(RejectingBindingGate::new("legion setup repair --confirm")),
     )
     .await
 }

--- a/engine/bins/legion-mcp/src/server.rs
+++ b/engine/bins/legion-mcp/src/server.rs
@@ -306,7 +306,7 @@ mod tests {
 
     impl ReleaseBindingGate for FailingGate {
         fn verify_binding(&self) -> Result<VerifiedReleaseBinding, BindingFailure> {
-            Err(BindingFailure::new("legion setup --repair"))
+            Err(BindingFailure::new("legion setup repair --confirm"))
         }
     }
 
@@ -442,7 +442,10 @@ mod tests {
             .handle(request(1, "initialize", json!({})))
             .await
             .unwrap();
-        assert_eq!(initialize["error"]["message"], "legion setup --repair");
+        assert_eq!(
+            initialize["error"]["message"],
+            "legion setup repair --confirm"
+        );
         assert_eq!(initialize["error"]["data"]["code"], "RELEASE_BINDING");
         assert!(initialize["error"]["data"].get("retryable").is_some());
 
@@ -451,7 +454,10 @@ mod tests {
             request(3, "tools/call", json!({"name":"m1_status", "arguments":{}})),
         ] {
             let response = server.handle(request).await.unwrap();
-            assert_eq!(response["error"]["message"], "legion setup --repair");
+            assert_eq!(
+                response["error"]["message"],
+                "legion setup repair --confirm"
+            );
             assert!(response.get("result").is_none());
         }
         assert_eq!(api.invocations.load(Ordering::SeqCst), 0);

--- a/engine/bins/legion/src/cli.rs
+++ b/engine/bins/legion/src/cli.rs
@@ -226,7 +226,7 @@ struct DoctorSummary {
 
 const M1_COMPOSITION_SCHEMA_VERSION: u32 = 1;
 const M1_STATE_SCHEMA_VERSION: u32 = 1;
-const M1_REPAIR: &str = "legion setup --repair";
+const M1_REPAIR: &str = "legion setup repair --confirm";
 const M1_RIGHTKIT_AX_VERSION: &str = "0.2.0";
 const M1_RIGHTKIT_AX_SOURCE_COMMIT: &str = "01f52555202da3dffc6b649ca44e803b55238081";
 const M1_INSTALLED_COMPOSITION: &str = "share/legion/composition.json";

--- a/engine/bins/legion/src/commands/setup.rs
+++ b/engine/bins/legion/src/commands/setup.rs
@@ -17,6 +17,13 @@ const QUALIFICATION_TOOL: &str = "legion_m1_status";
 const QUALIFICATION_SERVER: &str = "legion";
 const QUALIFICATION_TIMEOUT: Duration = Duration::from_secs(180);
 const QUALIFICATION_MCP_ARGS: [&str; 2] = ["serve", "--stdio"];
+const EXPECTED_RELEASE_VERSION: &str = env!("CARGO_PKG_VERSION");
+const PLUGIN_MANIFEST_PATHS: [&str; 2] = ["plugin.json", ".claude-plugin/plugin.json"];
+const CANONICAL_NATIVE_RELEASE_IDENTITY_PATH: &str = "release.json";
+const PLUGIN_RELEASE_IDENTITY_PATHS: [&str; 2] = [
+    "share/legion/release-binding.json",
+    "share/legion/identity/release-identity.json",
+];
 
 /// `legion setup [--dry-run] [--client]` is the installed-product lifecycle
 /// surface; lifecycle subcommands include `legion setup purge --confirm`.
@@ -245,14 +252,24 @@ async fn lifecycle(
     let recovery = registry.recover().map_err(setup_error)?;
     let host_integrations = preview_host_integrations(&request)?;
     let preview = registry.preview(request).map_err(setup_error)?;
+    let preview_value = serde_json::to_value(&preview)
+        .map_err(|error| CommandError::incomplete(error.to_string()))?;
+    let live_identity = inspect_live_identity(&host_integrations)?;
+    let (status, remediation) = setup_health(
+        &preview_value["clients"],
+        &host_integrations,
+        &live_identity,
+    );
     if !args.confirm || args.dry_run {
         return Ok(json!({
             "schemaVersion": 1,
             "kind": "legion-setup-preview",
-            "status": "complete",
+            "status": status,
+            "remediation": remediation,
             "recovery": recovery,
             "preview": preview,
             "hostIntegrations": host_integrations,
+            "liveIdentity": live_identity,
         }));
     }
     let confirmation = legion_host::PlanConfirmation {
@@ -265,13 +282,23 @@ async fn lifecycle(
     let integration_request = confirmed.preview.request.clone();
     let execution = registry.execute(confirmed).map_err(setup_error)?;
     let host_integrations = apply_host_integrations(&integration_request)?;
+    let execution_value = serde_json::to_value(&execution)
+        .map_err(|error| CommandError::incomplete(error.to_string()))?;
+    let live_identity = inspect_live_identity(&host_integrations)?;
+    let (status, remediation) = setup_health(
+        &execution_value["clients"],
+        &host_integrations,
+        &live_identity,
+    );
     Ok(json!({
         "schemaVersion": 1,
         "kind": "legion-setup-execution",
-        "status": "complete",
+        "status": status,
+        "remediation": remediation,
         "recovery": recovery,
         "execution": execution,
         "hostIntegrations": host_integrations,
+        "liveIdentity": live_identity,
     }))
 }
 
@@ -281,34 +308,51 @@ async fn preview(args: SetupPreviewArgs, cancellation: CancellationToken) -> Com
     let recovery = registry.recover().map_err(setup_error)?;
     let host_integrations = preview_host_integrations(&request)?;
     let preview = registry.preview(request).map_err(setup_error)?;
+    let preview_value = serde_json::to_value(&preview)
+        .map_err(|error| CommandError::incomplete(error.to_string()))?;
+    let live_identity = inspect_live_identity(&host_integrations)?;
+    let (status, remediation) = setup_health(
+        &preview_value["clients"],
+        &host_integrations,
+        &live_identity,
+    );
     if let Some(path) = args.out {
         write_json(&path, &preview)?;
     }
     Ok(json!({
         "schemaVersion": 1,
         "kind": "legion-setup-preview",
-        "status": "complete",
+        "status": status,
+        "remediation": remediation,
         "recovery": recovery,
         "preview": preview,
         "hostIntegrations": host_integrations,
+        "liveIdentity": live_identity,
     }))
 }
 
 fn status(args: SetupClientArgs) -> CommandResult {
-    let release = installed_bound_release()?;
+    let installed = installed_release()?;
+    let release = bound_release(&installed.manifest);
     let selector = selector(args.client);
     let mut registry =
         legion_host::SetupRegistry::open_platform(release.clone()).map_err(setup_error)?;
     let recovery = registry.recover().map_err(setup_error)?;
     let clients = registry.status(&selector).map_err(setup_error)?;
     let host_integrations = inspect_host_integrations(&selector, &release)?;
+    let clients_value = serde_json::to_value(&clients)
+        .map_err(|error| CommandError::incomplete(error.to_string()))?;
+    let live_identity = inspect_live_identity(&host_integrations)?;
+    let (status, remediation) = setup_health(&clients_value, &host_integrations, &live_identity);
     Ok(json!({
         "schemaVersion": 1,
         "kind": "legion-setup-status",
-        "status": "complete",
+        "status": status,
+        "remediation": remediation,
         "recovery": recovery,
         "clients": clients,
         "hostIntegrations": host_integrations,
+        "liveIdentity": live_identity,
     }))
 }
 
@@ -348,13 +392,23 @@ async fn execute(
         .map_err(setup_error)?;
     let execution = registry.execute(confirmed).map_err(setup_error)?;
     let host_integrations = apply_host_integrations(&integration_request)?;
+    let execution_value = serde_json::to_value(&execution)
+        .map_err(|error| CommandError::incomplete(error.to_string()))?;
+    let live_identity = inspect_live_identity(&host_integrations)?;
+    let (status, remediation) = setup_health(
+        &execution_value["clients"],
+        &host_integrations,
+        &live_identity,
+    );
     Ok(json!({
         "schemaVersion": 1,
         "kind": "legion-setup-execution",
-        "status": "complete",
+        "status": status,
+        "remediation": remediation,
         "recovery": recovery,
         "execution": execution,
         "hostIntegrations": host_integrations,
+        "liveIdentity": live_identity,
     }))
 }
 
@@ -513,7 +567,7 @@ async fn validate_client_evidence(
                 || !fresh_qualification.completed
             {
                 return Err(CommandError::incomplete(format!(
-                    "live client qualification changed for {}; run legion setup --repair",
+                    "live client qualification changed for {}; run legion setup repair --confirm",
                     client.client_id
                 )));
             }
@@ -592,7 +646,7 @@ fn validate_proof_pair(
         && qualification_path.is_file();
     if !valid {
         return Err(CommandError::incomplete(format!(
-            "client qualification evidence does not bind {} to a resolved launcher, completed MCP call, and installed release; run legion setup --repair",
+            "client qualification evidence does not bind {} to a resolved launcher, completed MCP call, and installed release; run legion setup repair --confirm",
             client.client_id
         )));
     }
@@ -619,13 +673,24 @@ async fn qualify_discovered_clients(
             qualified.push(client);
             continue;
         }
-        let (command, qualification) = qualify_client(
+        let result = qualify_client(
             &client.client_id,
             release,
             platform_state_root,
             cancellation.clone(),
         )
-        .await?;
+        .await;
+        let (command, qualification) = match result {
+            Ok(result) => result,
+            Err(error) if error.code == 2 && !cancellation.is_cancelled() => {
+                // A missing or incompatible client is a truthful baseline.  Keep
+                // it in the request so registry + host repair can reconcile
+                // owned projections without inventing qualification evidence.
+                qualified.push(client);
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
         let root = platform_state_root.join("qualification");
         std::fs::create_dir_all(&root).map_err(io_error)?;
         let command_path = root.join(format!("{}-command.json", client.client_id));
@@ -1066,6 +1131,520 @@ fn parse_embedded_json(text: &str) -> Option<Value> {
     })
 }
 
+fn inspect_live_identity(host_integrations: &Value) -> Result<Value, CommandError> {
+    let installed = installed_release()?;
+    let executable_state = if installed.manifest.release_version == EXPECTED_RELEASE_VERSION {
+        "current"
+    } else {
+        "stale"
+    };
+    let executable = json!({
+        "path": installed.executable_path.clone(),
+        "manifestPath": installed.manifest_path.clone(),
+        "releaseVersion": installed.manifest.release_version.clone(),
+        "expectedReleaseVersion": EXPECTED_RELEASE_VERSION,
+        "state": executable_state,
+        "runtimeDigest": installed.manifest.runtime.sha256.clone(),
+        "runtimePlatform": installed.manifest.runtime.platform.clone(),
+        "runtimeArchitecture": installed.manifest.runtime.architecture.clone(),
+    });
+    let plugin = inspect_live_plugin(&installed, host_integrations);
+    let projections = inspect_live_projections(&installed.manifest, host_integrations);
+    Ok(json!({
+        "executable": executable,
+        "plugin": plugin,
+        "projections": projections,
+    }))
+}
+
+fn inspect_live_plugin(
+    installed: &legion_runtime::release_binding::InstalledRelease,
+    host_integrations: &Value,
+) -> Value {
+    let Some(claude) = integration_inspection(host_integrations, "claudeCodeLegacy") else {
+        return json!({
+            "state": "not_selected",
+            "expectedReleaseVersion": EXPECTED_RELEASE_VERSION,
+            "activeReleaseVersion": installed.manifest.release_version,
+            "roots": [],
+            "cacheMutation": "never",
+        });
+    };
+    let mut roots = BTreeMap::new();
+    if let Some(root) = installed.manifest_path.parent().and_then(Path::parent) {
+        roots.insert(root.to_path_buf(), ());
+    }
+    if let Some(root) = installed.manifest_path.parent() {
+        roots.insert(root.to_path_buf(), ());
+    }
+    if let Some(generations) = claude
+        .get("pluginCacheGenerations")
+        .and_then(Value::as_array)
+    {
+        for generation in generations {
+            if let Some(path) = generation.get("installPath").and_then(Value::as_str) {
+                roots.insert(PathBuf::from(path), ());
+            }
+        }
+    }
+    let records = roots
+        .keys()
+        .map(|root| {
+            inspect_plugin_root(root, installed.manifest_path.parent(), &installed.manifest)
+        })
+        .collect::<Vec<_>>();
+    let state = if records.iter().any(|record| record["state"] == "current") {
+        "current"
+    } else if records.iter().any(|record| record["state"] == "stale") {
+        "stale"
+    } else if records.iter().any(|record| record["state"] == "foreign") {
+        "foreign"
+    } else {
+        "incomplete"
+    };
+    json!({
+        "state": state,
+        "expectedReleaseVersion": EXPECTED_RELEASE_VERSION,
+        "activeReleaseVersion": installed.manifest.release_version,
+        "roots": records,
+        "cacheMutation": "never",
+    })
+}
+
+fn inspect_plugin_root(
+    root: &Path,
+    canonical_root: Option<&Path>,
+    active_manifest: &legion_runtime::ReleaseManifest,
+) -> Value {
+    let is_canonical_root = canonical_root.is_some_and(|path| path == root);
+    let mut manifests = Vec::new();
+    let mut manifest_seen = false;
+    let mut manifest_matches = false;
+    let mut manifest_foreign = false;
+    let mut manifest_mismatch = false;
+    let mut manifest_invalid = false;
+    for relative in PLUGIN_MANIFEST_PATHS {
+        let path = root.join(relative);
+        if !path.is_file() {
+            continue;
+        }
+        manifest_seen = true;
+        match std::fs::read(&path) {
+            Ok(bytes) => {
+                let digest = legion_catalog::hex_digest(&bytes);
+                match serde_json::from_slice::<Value>(&bytes) {
+                    Ok(value) => {
+                        let name = value.get("name").and_then(Value::as_str);
+                        let version = value.get("version").and_then(Value::as_str);
+                        let name_ok = name == Some("legion");
+                        let version_ok = version == Some(active_manifest.release_version.as_str());
+                        if !name_ok {
+                            manifest_foreign = true;
+                        } else if version_ok {
+                            manifest_matches = true;
+                        } else if version.is_some_and(|value| !value.trim().is_empty()) {
+                            manifest_mismatch = true;
+                        } else {
+                            manifest_invalid = true;
+                        }
+                        manifests.push(json!({
+                            "path": path,
+                            "present": true,
+                            "digest": digest,
+                            "name": name,
+                            "version": version,
+                            "expectedVersion": EXPECTED_RELEASE_VERSION,
+                            "matchesActiveRelease": name_ok && version_ok,
+                        }));
+                    }
+                    Err(error) => {
+                        manifest_invalid = true;
+                        manifests.push(json!({
+                            "path": path,
+                            "present": true,
+                            "digest": digest,
+                            "error": error.to_string(),
+                        }));
+                    }
+                }
+            }
+            Err(error) => {
+                manifest_invalid = true;
+                manifests.push(json!({
+                    "path": path,
+                    "present": true,
+                    "error": error.to_string(),
+                }));
+            }
+        }
+    }
+
+    let mut identities = Vec::new();
+    let mut identity_seen = false;
+    let mut identity_mismatch = false;
+    let mut identity_invalid = false;
+    let mut canonical_identity_seen = false;
+    let mut canonical_identity_matches = false;
+    let mut identity_paths = Vec::new();
+    if is_canonical_root {
+        identity_paths.push((
+            "canonical",
+            root.join(CANONICAL_NATIVE_RELEASE_IDENTITY_PATH),
+        ));
+    }
+    identity_paths.extend(
+        PLUGIN_RELEASE_IDENTITY_PATHS
+            .into_iter()
+            .map(|relative| ("plugin", root.join(relative))),
+    );
+    for (kind, path) in identity_paths {
+        if !path.is_file() {
+            continue;
+        }
+        identity_seen = true;
+        if kind == "canonical" {
+            canonical_identity_seen = true;
+        }
+        match std::fs::read(&path) {
+            Ok(bytes) => {
+                let digest = legion_catalog::hex_digest(&bytes);
+                match legion_runtime::load_release_manifest(&path) {
+                    Ok(manifest) => {
+                        let matches_active = manifest == *active_manifest;
+                        if kind == "canonical" && matches_active {
+                            canonical_identity_matches = true;
+                        }
+                        if !matches_active {
+                            identity_mismatch = true;
+                        }
+                        identities.push(json!({
+                            "kind": kind,
+                            "path": path,
+                            "present": true,
+                            "digest": digest,
+                            "releaseVersion": manifest.release_version,
+                            "matchesActiveRelease": matches_active,
+                        }));
+                    }
+                    Err(error) => {
+                        identity_invalid = true;
+                        identities.push(json!({
+                            "kind": kind,
+                            "path": path,
+                            "present": true,
+                            "digest": digest,
+                            "error": error.to_string(),
+                        }));
+                    }
+                }
+            }
+            Err(error) => {
+                identity_invalid = true;
+                identities.push(json!({
+                    "kind": kind,
+                    "path": path,
+                    "present": true,
+                    "error": error.to_string(),
+                }));
+            }
+        }
+    }
+    let state = if is_canonical_root {
+        if !canonical_identity_seen || manifest_invalid || identity_invalid {
+            "incomplete"
+        } else if !canonical_identity_matches
+            || identity_mismatch
+            || active_manifest.release_version != EXPECTED_RELEASE_VERSION
+            || manifest_foreign
+            || manifest_mismatch
+            || (manifest_seen && !manifest_matches)
+        {
+            "stale"
+        } else {
+            "current"
+        }
+    } else if manifest_foreign && !manifest_matches && !manifest_invalid && !identity_seen {
+        "foreign"
+    } else if !manifest_seen || manifest_invalid || identity_invalid {
+        "incomplete"
+    } else if !manifest_matches
+        || manifest_mismatch
+        || identity_mismatch
+        || active_manifest.release_version != EXPECTED_RELEASE_VERSION
+    {
+        "stale"
+    } else {
+        "current"
+    };
+    json!({
+        "root": root,
+        "canonicalNativeRoot": is_canonical_root,
+        "state": state,
+        "manifests": manifests,
+        "releaseIdentities": identities,
+        "cacheMutation": "never",
+    })
+}
+
+fn inspect_live_projections(
+    manifest: &legion_runtime::ReleaseManifest,
+    host_integrations: &Value,
+) -> Value {
+    let generation = format!(
+        "{}:{}",
+        EXPECTED_RELEASE_VERSION, manifest.declarative_assets_sha256
+    );
+    let mut projections = serde_json::Map::new();
+    if let Some(claude) = integration_inspection(host_integrations, "claudeCodeLegacy") {
+        let canonical_trusted = claude
+            .get("canonicalSkillsRootTrusted")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let missing = claude
+            .get("canonicalMissingSkillIds")
+            .and_then(Value::as_array)
+            .map(|values| values.len())
+            .unwrap_or(0);
+        let cache_error = claude
+            .get("pluginCacheError")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let cache_generations = claude
+            .get("pluginCacheGenerations")
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .map(|value| {
+                        let version = value.get("version").and_then(Value::as_str);
+                        let canonical = value
+                            .get("canonicalGeneration")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false);
+                        let install_exists = value
+                            .get("installPathExists")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false);
+                        let manifest_present = value
+                            .get("legionPluginManifest")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false);
+                        let state = if !install_exists || !manifest_present {
+                            "incomplete"
+                        } else if version != Some(EXPECTED_RELEASE_VERSION)
+                            || manifest.release_version != EXPECTED_RELEASE_VERSION
+                            || !canonical
+                        {
+                            "stale"
+                        } else {
+                            "current"
+                        };
+                        json!({
+                            "generation": value.get("generation"),
+                            "version": version,
+                            "expectedVersion": EXPECTED_RELEASE_VERSION,
+                            "canonicalGeneration": canonical,
+                            "state": state,
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let standalone = claude
+            .get("standaloneProjections")
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .map(|value| {
+                        let ownership = value.get("ownership").cloned().unwrap_or(Value::Null);
+                        let unproven = ownership == Value::String("unproven".into());
+                        let state = if unproven { "preserved" } else { "stale" };
+                        json!({
+                            "id": value.get("id"),
+                            "path": value.get("path"),
+                            "ownership": ownership,
+                            "state": state,
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let state = if cache_error.is_some() || !canonical_trusted {
+            "incomplete"
+        } else if missing > 0
+            || manifest.release_version != EXPECTED_RELEASE_VERSION
+            || cache_generations
+                .iter()
+                .any(|item| item["state"] == "stale")
+            || standalone.iter().any(|item| item["state"] == "stale")
+        {
+            "stale"
+        } else {
+            "current"
+        };
+        projections.insert(
+            "claudeCodeLegacy".into(),
+            json!({
+                "state": state,
+                "expectedGeneration": generation,
+                "canonicalSkillsRootTrusted": canonical_trusted,
+                "canonicalMissingSkillCount": missing,
+                "pluginCacheError": cache_error,
+                "pluginCacheGenerations": cache_generations,
+                "standaloneProjections": standalone,
+                "cacheMutation": "never",
+            }),
+        );
+    }
+    if let Some(codex) = integration_inspection(host_integrations, "codexSkills") {
+        let ledger_error = codex.get("ledgerError").and_then(Value::as_str);
+        let statuses = codex
+            .get("statuses")
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .map(|value| {
+                        let state = value
+                            .get("state")
+                            .and_then(Value::as_str)
+                            .unwrap_or("unknown");
+                        json!({
+                            "id": value.get("id"),
+                            "path": value.get("path"),
+                            "state": state,
+                            "ledgerGeneration": value.get("ledgerGeneration"),
+                            "sourceDigest": value.get("sourceDigest"),
+                            "destinationDigest": value.get("destinationDigest"),
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let state = if ledger_error.is_some()
+            || statuses.iter().any(|item| {
+                matches!(
+                    item["state"].as_str(),
+                    Some("conflict") | Some("foreign") | Some("retired_conflict")
+                )
+            }) {
+            "incomplete"
+        } else if manifest.release_version != EXPECTED_RELEASE_VERSION
+            || statuses.iter().any(|item| {
+                matches!(
+                    item["state"].as_str(),
+                    Some("missing") | Some("stale") | Some("retired_owned")
+                )
+            })
+        {
+            "stale"
+        } else {
+            "current"
+        };
+        projections.insert(
+            "codexSkills".into(),
+            json!({
+                "state": state,
+                "expectedGeneration": generation,
+                "ledgerError": ledger_error,
+                "statuses": statuses,
+            }),
+        );
+    }
+    Value::Object(projections)
+}
+
+fn integration_inspection<'a>(integrations: &'a Value, key: &str) -> Option<&'a Value> {
+    let value = integrations.get(key)?;
+    if value.get("canonicalSkillsRootTrusted").is_some() || value.get("destinationRoot").is_some() {
+        return Some(value);
+    }
+    value.get("inspection").or_else(|| {
+        value
+            .get("preview")
+            .and_then(|preview| preview.get("inspection"))
+    })
+}
+
+fn setup_health(
+    clients: &Value,
+    host_integrations: &Value,
+    live_identity: &Value,
+) -> (&'static str, Vec<String>) {
+    let mut remediation = Vec::new();
+    if live_identity["executable"]["state"] != "current" {
+        remediation.push(format!(
+            "live Legion executable is stale ({}; expected {})",
+            live_identity["executable"]["releaseVersion"]
+                .as_str()
+                .unwrap_or("unknown"),
+            EXPECTED_RELEASE_VERSION
+        ));
+    }
+    match clients.as_array() {
+        Some(values) if values.is_empty() => remediation
+            .push("no supported client is registered with complete setup evidence".into()),
+        Some(values) => {
+            for client in values {
+                let installed = client
+                    .get("installed")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let fidelity = client
+                    .get("fidelity")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Unavailable");
+                if !installed || fidelity != "Full" {
+                    remediation.push(format!(
+                        "client {} is incomplete ({fidelity}); run legion setup repair --confirm",
+                        client
+                            .get("clientId")
+                            .and_then(Value::as_str)
+                            .unwrap_or("unknown")
+                    ));
+                }
+            }
+        }
+        None => remediation.push("setup client status is unavailable".into()),
+    }
+    if let Some(plugin_state) = live_identity["plugin"]["state"].as_str() {
+        if !matches!(plugin_state, "current" | "not_selected") {
+            remediation.push(format!(
+                "Claude plugin identity is {plugin_state}; repair observes cache and preserves its files"
+            ));
+        }
+    }
+    if let Some(projections) = live_identity["projections"].as_object() {
+        for (client, projection) in projections {
+            if let Some(state) = projection.get("state").and_then(Value::as_str) {
+                if state != "current" {
+                    remediation.push(format!(
+                        "{client} projection is {state}; run legion setup repair --confirm"
+                    ));
+                }
+            }
+        }
+    }
+    // Keep direct host observations in output-derived health so repair result
+    // shapes (inspection nested under `preview`) remain truthful too.
+    if integration_inspection(host_integrations, "codexSkills")
+        .and_then(|value| value.get("ledgerError"))
+        .is_some_and(|value| !value.is_null())
+    {
+        remediation.push(
+            "Codex ownership ledger is invalid; conflicting projections are preserved".into(),
+        );
+    }
+    remediation.sort();
+    remediation.dedup();
+    if remediation.is_empty() {
+        ("complete", remediation)
+    } else {
+        ("incomplete", remediation)
+    }
+}
+
 struct HostIntegrationInputs {
     claude: Option<legion_host::ClaudeLegacyInput>,
     codex: Option<legion_host::CodexSkillsInput>,
@@ -1235,21 +1814,24 @@ fn host_error(error: legion_host::HostError) -> CommandError {
 
 fn installed_bound_release() -> Result<legion_host::BoundRelease, CommandError> {
     let installed = installed_release()?;
-    let manifest = installed.manifest;
-    Ok(legion_host::BoundRelease {
-        release_version: manifest.release_version,
-        runtime_digest: manifest.runtime.sha256,
-        capability_catalog_hash: manifest.capability_catalog_sha256,
-        mcp_tool_schema_hash: manifest.mcp_tool_schema_sha256,
-        declarative_asset_schema_hash: manifest.declarative_assets_sha256,
+    Ok(bound_release(&installed.manifest))
+}
+
+fn bound_release(manifest: &legion_runtime::ReleaseManifest) -> legion_host::BoundRelease {
+    legion_host::BoundRelease {
+        release_version: manifest.release_version.clone(),
+        runtime_digest: manifest.runtime.sha256.clone(),
+        capability_catalog_hash: manifest.capability_catalog_sha256.clone(),
+        mcp_tool_schema_hash: manifest.mcp_tool_schema_sha256.clone(),
+        declarative_asset_schema_hash: manifest.declarative_assets_sha256.clone(),
         state_compatibility: manifest.state_schema_version.to_string(),
-    })
+    }
 }
 
 fn installed_release() -> Result<legion_runtime::release_binding::InstalledRelease, CommandError> {
     legion_runtime::release_binding::load_installed_release().map_err(|error| {
         CommandError::incomplete(format!(
-            "installed release binding unavailable: {error}; run legion setup --repair"
+            "installed release binding unavailable: {error}; run legion setup repair --confirm"
         ))
     })
 }
@@ -1291,7 +1873,7 @@ fn open_registry(
         return Err(setup_error(legion_host::SetupError {
             code: legion_host::SetupErrorCode::ReleaseBindingMismatch,
             remediation:
-                "setup plan release differs from installed release; run legion setup --repair"
+                "setup plan release differs from installed release; run legion setup repair --confirm"
                     .into(),
         }));
     }
@@ -1328,6 +1910,80 @@ fn setup_error(error: legion_host::SetupError) -> CommandError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{
+        fs,
+        path::PathBuf,
+        sync::atomic::{AtomicU64, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    struct TempRoot(PathBuf);
+
+    impl TempRoot {
+        fn new(label: &str) -> Self {
+            static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+            let root = std::env::temp_dir().join(format!(
+                "legion-setup-live-{}-{}-{}-{}",
+                std::process::id(),
+                label,
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("clock")
+                    .as_nanos(),
+                NEXT_ID.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir_all(&root).expect("temporary setup root");
+            Self(root)
+        }
+    }
+
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn test_release_manifest() -> legion_runtime::ReleaseManifest {
+        let digest = "0".repeat(64);
+        legion_runtime::ReleaseManifest {
+            release_version: EXPECTED_RELEASE_VERSION.into(),
+            runtime: legion_runtime::RuntimeIdentity {
+                platform: std::env::consts::OS.into(),
+                architecture: std::env::consts::ARCH.into(),
+                sha256: digest.clone(),
+                provenance: "rightkit-release://setup-live-test".into(),
+            },
+            capability_catalog_sha256: digest.clone(),
+            mcp_tool_schema_sha256: digest.clone(),
+            declarative_assets_sha256: digest,
+            state_schema_version: 1,
+            rightkit_ax: legion_runtime::RightkitAxIdentity {
+                version: "0.2.0".into(),
+                source_commit: "01f52555202da3dffc6b649ca44e803b55238081".into(),
+            },
+        }
+    }
+
+    fn write_release(path: &Path, manifest: &legion_runtime::ReleaseManifest) {
+        fs::create_dir_all(path.parent().expect("release parent")).expect("release directory");
+        fs::write(
+            path,
+            serde_json::to_vec(manifest).expect("release manifest JSON"),
+        )
+        .expect("release manifest");
+    }
+
+    fn write_plugin_manifest(root: &Path, version: &str) {
+        let path = root.join(".claude-plugin/plugin.json");
+        fs::create_dir_all(path.parent().expect("plugin manifest parent"))
+            .expect("plugin manifest directory");
+        fs::write(
+            path,
+            serde_json::to_vec(&json!({"name": "legion", "version": version}))
+                .expect("plugin manifest JSON"),
+        )
+        .expect("plugin manifest");
+    }
 
     #[test]
     fn m1_result_parser_preserves_host_requirements_and_degradation() {
@@ -1359,5 +2015,109 @@ mod tests {
             parsed.host_requirements[0]["degradation"],
             "worker unavailable"
         );
+    }
+
+    #[test]
+    fn live_plugin_identity_accepts_native_release_and_current_claude_cache() {
+        let temp = TempRoot::new("current");
+        let native_root = temp.0.join("native/share/legion");
+        let current_cache = temp.0.join("cache/0.1.0");
+        let old_cache = temp.0.join("cache/0.1.0-dev.3");
+        let manifest = test_release_manifest();
+        write_release(&native_root.join("release.json"), &manifest);
+        write_plugin_manifest(&current_cache, EXPECTED_RELEASE_VERSION);
+        write_plugin_manifest(&old_cache, "0.1.0-dev.3");
+
+        let installed = legion_runtime::release_binding::InstalledRelease {
+            manifest: manifest.clone(),
+            manifest_path: native_root.join("release.json"),
+            executable_path: temp.0.join("bin/legion.exe"),
+        };
+        let integrations = json!({
+            "claudeCodeLegacy": {
+                "inspection": {
+                    "pluginCacheGenerations": [
+                        {"installPath": current_cache.clone(), "version": EXPECTED_RELEASE_VERSION},
+                        {"installPath": old_cache.clone(), "version": "0.1.0-dev.3"}
+                    ]
+                }
+            }
+        });
+
+        let inspected = inspect_live_plugin(&installed, &integrations);
+        assert_eq!(inspected["state"], "current");
+        let roots = inspected["roots"].as_array().expect("plugin roots");
+        let native = roots
+            .iter()
+            .find(|root| root["canonicalNativeRoot"] == true)
+            .expect("native release root");
+        assert_eq!(native["state"], "current");
+        assert!(native["releaseIdentities"]
+            .as_array()
+            .expect("native identities")
+            .iter()
+            .any(|identity| {
+                identity["kind"] == "canonical" && identity["matchesActiveRelease"] == true
+            }));
+        let cache_state = |path: &Path| {
+            roots
+                .iter()
+                .find(|root| root["root"].as_str() == path.to_str())
+                .and_then(|root| root["state"].as_str())
+        };
+        assert_eq!(cache_state(&current_cache), Some("current"));
+        assert_eq!(cache_state(&old_cache), Some("stale"));
+    }
+
+    #[test]
+    fn live_plugin_identity_marks_mismatched_native_release_stale() {
+        let temp = TempRoot::new("mismatch");
+        let native_root = temp.0.join("native/share/legion");
+        let active = test_release_manifest();
+        let mut mismatched = active.clone();
+        mismatched.release_version = "0.1.0-dev.3".into();
+        write_release(&native_root.join("release.json"), &mismatched);
+
+        let inspected = inspect_plugin_root(&native_root, Some(&native_root), &active);
+
+        assert_eq!(inspected["state"], "stale");
+        assert_eq!(
+            inspected["releaseIdentities"]
+                .as_array()
+                .expect("native identities")
+                .len(),
+            1
+        );
+        assert_eq!(
+            inspected["releaseIdentities"][0]["matchesActiveRelease"],
+            false
+        );
+    }
+
+    #[test]
+    fn setup_health_uses_supported_repair_command() {
+        let clients = json!([{
+            "clientId": "codex",
+            "installed": false,
+            "fidelity": "Unavailable"
+        }]);
+        let live_identity = json!({
+            "executable": {"state": "current"},
+            "plugin": {"state": "current"},
+            "projections": {"codexSkills": {"state": "stale"}}
+        });
+
+        let (status, remediation) = setup_health(&clients, &json!({}), &live_identity);
+
+        assert_eq!(status, "incomplete");
+        assert!(remediation.iter().any(|item| {
+            item == "client codex is incomplete (Unavailable); run legion setup repair --confirm"
+        }));
+        assert!(remediation.iter().any(|item| {
+            item == "codexSkills projection is stale; run legion setup repair --confirm"
+        }));
+        assert!(remediation
+            .iter()
+            .all(|item| !item.contains("legion setup --repair")));
     }
 }

--- a/engine/bins/legion/tests/m1_vertical_slice.rs
+++ b/engine/bins/legion/tests/m1_vertical_slice.rs
@@ -439,7 +439,10 @@ fn mismatch_remains_a_stdio_protocol_failure_without_tools() {
         &mut stdout,
         json!({"jsonrpc":"2.0", "id":1, "method":"initialize", "params":{}}),
     );
-    assert_eq!(initialized["error"]["message"], "legion setup --repair");
+    assert_eq!(
+        initialized["error"]["message"],
+        "legion setup repair --confirm"
+    );
     assert!(initialized.get("result").is_none());
 
     let listed = request(
@@ -447,7 +450,7 @@ fn mismatch_remains_a_stdio_protocol_failure_without_tools() {
         &mut stdout,
         json!({"jsonrpc":"2.0", "id":2, "method":"tools/list", "params":{}}),
     );
-    assert_eq!(listed["error"]["message"], "legion setup --repair");
+    assert_eq!(listed["error"]["message"], "legion setup repair --confirm");
     assert!(listed.get("result").is_none());
 
     drop(stdin);

--- a/engine/bins/legion/tests/m2_plugin_root.rs
+++ b/engine/bins/legion/tests/m2_plugin_root.rs
@@ -183,7 +183,7 @@ fn portable_package(fixture: &Fixture) -> PathBuf {
         let path = root.join(relative);
         fs::create_dir_all(path.parent().expect("package parent")).expect("package directory");
         let content = match relative {
-            "plugin.json" => br#"{"name":"legion"}"#.as_slice(),
+            "plugin.json" => include_bytes!("../../../assets/legion-plugin/plugin.json").as_slice(),
             "mcp.json" => br#"{"$schema":"https://agent-plugins.org/schemas/1.0.0/mcp.schema.json","mcpServers":{"legion":{"type":"stdio","command":"legion","args":["serve","--stdio","--plugin-root","${PLUGIN_ROOT}"]}}}"#.as_slice(),
             "skills/legion/SKILL.md" => b"---\nname: legion\n---\nUse Legion.",
             "share/legion/release-binding.json" => {
@@ -300,7 +300,7 @@ fn plugin_root_release_binding_mismatch_fails_closed_before_mcp_startup() {
 
     assert_eq!(output.status.code(), Some(2));
     assert!(output.stdout.is_empty(), "MCP must not have started");
-    assert!(String::from_utf8_lossy(&output.stderr).contains("legion setup --repair"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("legion setup repair --confirm"));
 }
 
 #[test]

--- a/engine/crates/legion-host/src/codex_skills.rs
+++ b/engine/crates/legion-host/src/codex_skills.rs
@@ -2,9 +2,10 @@
 //!
 //! Codex discovers plain Agent Skills at `$HOME/.agents/skills/<id>`.  Legion
 //! copies each release package verbatim from `assets/skills`; it never prefixes
-//! a skill id, transforms package contents, or claims a pre-existing tree.
-//! A private ledger under Legion platform state is the sole authority to update
-//! or remove a copied tree.
+//! a skill id or transforms package contents.  A pre-existing skill symlink is
+//! adopted only when its resolved package digest exactly matches the source,
+//! after which replacement creates the regular tree owned by the private
+//! ledger under Legion platform state.
 
 use crate::HostError;
 use legion_contracts::canonical_digest;
@@ -164,6 +165,7 @@ enum LedgerRead {
 enum DestinationTree {
     Absent,
     Digest(String),
+    CanonicalSymlink(String),
     Invalid,
 }
 
@@ -211,7 +213,7 @@ pub fn inspect_codex_skills(input: &CodexSkillsInput) -> Result<CodexSkillsInspe
         let source_digest = sources.get(id).map(|tree| tree.digest()).transpose()?;
         let path = destination_root.join(id);
         let destination = if destination_ok {
-            destination_tree(&path)?
+            destination_tree(&path, source_digest.as_deref())?
         } else {
             DestinationTree::Invalid
         };
@@ -246,7 +248,7 @@ pub fn inspect_codex_skills(input: &CodexSkillsInput) -> Result<CodexSkillsInspe
     for id in &retirement_ids {
         let path = destination_root.join(id);
         let destination = if destination_ok {
-            destination_tree(&path)?
+            destination_tree(&path, None)?
         } else {
             DestinationTree::Invalid
         };
@@ -551,26 +553,43 @@ fn execute_write(
     let ledger_path = ledger_path(&input.platform_state_root);
     let mut ledger = load_mutable_ledger(&ledger_path)?;
     let existing = ledger.entries.get(&current.id).cloned();
-    if current.kind == CodexSkillOperationKind::Install {
-        if !matches!(destination_tree(&destination)?, DestinationTree::Absent) {
-            return Ok(false);
-        }
+    let (replacing, expected_existing_digest) = if current.kind == CodexSkillOperationKind::Install
+    {
+        let replacing = match destination_tree(&destination, Some(source_digest.as_str()))? {
+            DestinationTree::Absent => false,
+            DestinationTree::CanonicalSymlink(digest) if digest == source_digest => true,
+            _ => return Ok(false),
+        };
         if existing.is_some()
             && existing.as_ref().map(|entry| entry.digest.as_str())
                 != current.expected_digest.as_deref()
         {
             return Ok(false);
         }
+        let expected = if replacing {
+            Some(source_digest.clone())
+        } else {
+            None
+        };
+        (replacing, expected)
     } else {
         let Some(existing) = existing.as_ref() else {
             return Ok(false);
         };
-        if current.expected_digest.as_deref() != Some(existing.digest.as_str())
-            || !matches!(destination_tree(&destination)?, DestinationTree::Digest(ref digest) if digest == &existing.digest)
-        {
+        if current.expected_digest.as_deref() != Some(existing.digest.as_str()) {
             return Ok(false);
         }
-    }
+        let replacing = match destination_tree(&destination, Some(source_digest.as_str()))? {
+            DestinationTree::Digest(digest) if digest == existing.digest => true,
+            DestinationTree::CanonicalSymlink(digest)
+                if digest == existing.digest && digest == source_digest =>
+            {
+                true
+            }
+            _ => return Ok(false),
+        };
+        (replacing, Some(existing.digest.clone()))
+    };
 
     let stage = create_stage_directory(&root, &current.id, "stage")?;
     if let Err(error) = materialize_tree(&stage, &tree) {
@@ -590,15 +609,16 @@ fn execute_write(
     ledger.entries.insert(
         current.id.clone(),
         CodexSkillsLedgerEntry {
-            digest: source_digest,
+            digest: source_digest.clone(),
             generation: input.generation.clone(),
         },
     );
     replace_with_stage(
         &destination,
         &stage,
-        matches!(current.kind, CodexSkillOperationKind::Update),
-        current.expected_digest.as_deref(),
+        replacing,
+        expected_existing_digest.as_deref(),
+        Some(source_digest.as_str()),
         &ledger_path,
         &ledger,
     )
@@ -647,7 +667,7 @@ fn execute_remove(
     if operation.expected_digest.as_deref() != Some(entry.digest.as_str()) {
         return Ok(false);
     }
-    match destination_tree(&destination)? {
+    match destination_tree(&destination, None)? {
         DestinationTree::Absent if removes_missing_ledger => {
             ledger.entries.remove(&operation.id);
             write_ledger(&ledger_path, &ledger)?;
@@ -674,6 +694,7 @@ fn replace_with_stage(
     stage: &Path,
     replacing: bool,
     expected_existing_digest: Option<&str>,
+    expected_source_digest: Option<&str>,
     ledger_path: &Path,
     ledger: &CodexSkillsLedger,
 ) -> Result<bool, HostError> {
@@ -699,7 +720,7 @@ fn replace_with_stage(
     let backup = create_stage_directory(root, id, "backup")?;
     fs::remove_dir(&backup).map_err(|error| io_error(&backup, error))?;
     fs::rename(destination, &backup).map_err(|error| io_error(destination, error))?;
-    let backup_tree = match destination_tree(&backup) {
+    let backup_tree = match destination_tree(&backup, expected_source_digest) {
         Ok(tree) => tree,
         Err(error) => {
             rollback_rename(&backup, destination)?;
@@ -707,11 +728,15 @@ fn replace_with_stage(
             return Err(error);
         }
     };
-    if !matches!(
-        backup_tree,
-        DestinationTree::Digest(ref digest)
-            if expected_existing_digest == Some(digest.as_str())
-    ) {
+    let backup_is_expected = match backup_tree {
+        DestinationTree::Digest(digest) => expected_existing_digest == Some(digest.as_str()),
+        DestinationTree::CanonicalSymlink(digest) => {
+            expected_source_digest == Some(digest.as_str())
+                && expected_existing_digest == Some(digest.as_str())
+        }
+        DestinationTree::Absent | DestinationTree::Invalid => false,
+    };
+    if !backup_is_expected {
         rollback_rename(&backup, destination)?;
         fs::remove_dir_all(stage).map_err(|error| io_error(stage, error))?;
         return Ok(false);
@@ -838,13 +863,30 @@ fn package_digest_at(path: &Path) -> Result<String, HostError> {
     tree.digest()
 }
 
-fn destination_tree(path: &Path) -> Result<DestinationTree, HostError> {
+fn resolved_package_digest(path: &Path) -> Result<String, HostError> {
+    let resolved = fs::canonicalize(path).map_err(|error| io_error(path, error))?;
+    package_digest_at(&resolved)
+}
+
+fn destination_tree(
+    path: &Path,
+    expected_source_digest: Option<&str>,
+) -> Result<DestinationTree, HostError> {
     match fs::symlink_metadata(path) {
         Err(error) if error.kind() == ErrorKind::NotFound => Ok(DestinationTree::Absent),
         Err(error) => Err(io_error(path, error)),
-        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
-            Ok(DestinationTree::Invalid)
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let Some(expected_source_digest) = expected_source_digest else {
+                return Ok(DestinationTree::Invalid);
+            };
+            match resolved_package_digest(path) {
+                Ok(digest) if digest == expected_source_digest => {
+                    Ok(DestinationTree::CanonicalSymlink(digest))
+                }
+                Ok(_) | Err(_) => Ok(DestinationTree::Invalid),
+            }
         }
+        Ok(metadata) if !metadata.is_dir() => Ok(DestinationTree::Invalid),
         Ok(_) => match package_tree(path, true) {
             Ok(tree) => Ok(DestinationTree::Digest(tree.digest()?)),
             Err(_) => Ok(DestinationTree::Invalid),
@@ -854,7 +896,9 @@ fn destination_tree(path: &Path) -> Result<DestinationTree, HostError> {
 
 fn destination_digest(destination: &DestinationTree) -> Option<String> {
     match destination {
-        DestinationTree::Digest(digest) => Some(digest.clone()),
+        DestinationTree::Digest(digest) | DestinationTree::CanonicalSymlink(digest) => {
+            Some(digest.clone())
+        }
         DestinationTree::Absent | DestinationTree::Invalid => None,
     }
 }
@@ -880,6 +924,16 @@ fn current_state(
             Some(entry) if destination_digest == &entry.digest => CodexSkillState::Stale,
             Some(_) | None => CodexSkillState::Conflict,
         },
+        DestinationTree::CanonicalSymlink(destination_digest) => match entry {
+            Some(entry)
+                if destination_digest == &entry.digest
+                    && source_digest == Some(entry.digest.as_str()) =>
+            {
+                CodexSkillState::Stale
+            }
+            None if source_digest == Some(destination_digest.as_str()) => CodexSkillState::Missing,
+            Some(_) | None => CodexSkillState::Conflict,
+        },
         DestinationTree::Invalid => CodexSkillState::Conflict,
     }
 }
@@ -899,6 +953,7 @@ fn retired_state(
             Some(_) => CodexSkillState::RetiredConflict,
             None => CodexSkillState::Foreign,
         },
+        DestinationTree::CanonicalSymlink(_) => CodexSkillState::RetiredConflict,
         DestinationTree::Invalid => CodexSkillState::RetiredConflict,
     }
 }
@@ -1313,6 +1368,26 @@ mod tests {
         }
     }
 
+    #[cfg(any(unix, windows))]
+    fn make_dir_symlink(target: &Path, link: &Path) -> bool {
+        #[cfg(unix)]
+        let result = std::os::unix::fs::symlink(target, link);
+        #[cfg(windows)]
+        let result = std::os::windows::fs::symlink_dir(target, link);
+        match result {
+            Ok(()) => true,
+            Err(error) if cfg!(windows) && error.kind() == std::io::ErrorKind::PermissionDenied => {
+                false
+            }
+            Err(error) => panic!("cannot create test directory symlink: {error}"),
+        }
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    fn make_dir_symlink(_target: &Path, _link: &Path) -> bool {
+        panic!("directory symlink tests require a supported platform")
+    }
+
     #[test]
     fn apply_copies_full_plain_package_and_writes_ownership_ledger() {
         let temp = TempRoot::new("copy-full-package");
@@ -1337,6 +1412,220 @@ mod tests {
             inspect_codex_skills(&input).unwrap().statuses[0].state,
             CodexSkillState::Healthy
         );
+    }
+
+    #[test]
+    fn apply_adopts_exact_source_symlink_without_touching_target() {
+        let temp = TempRoot::new("adopt-source-symlink");
+        let input = input(&temp, &["audit"], &[], "dev.1");
+        write_skill(&input.assets_skills_root, "audit", "audit v1");
+        let canonical_root = temp.0.join("canonical");
+        write_skill(&canonical_root, "audit", "audit v1");
+
+        let target = canonical_root.join("audit");
+        let destination = input.home.join(".agents").join("skills").join("audit");
+        fs::create_dir_all(destination.parent().unwrap()).unwrap();
+        if !make_dir_symlink(&target, &destination) {
+            return;
+        }
+        let source_digest = package_digest_at(&input.assets_skills_root.join("audit")).unwrap();
+        let target_digest = package_digest_at(&target).unwrap();
+
+        let preview = preview_codex_skills(&input).unwrap();
+        assert_eq!(
+            preview.inspection.statuses[0].state,
+            CodexSkillState::Missing
+        );
+        assert_eq!(
+            preview.inspection.statuses[0].destination_digest.as_deref(),
+            Some(source_digest.as_str())
+        );
+        assert_eq!(preview.operations[0].kind, CodexSkillOperationKind::Install);
+
+        let applied = apply_codex_skills(&input).unwrap();
+        assert_eq!(applied.applied.len(), 1);
+        assert_eq!(applied.applied[0].kind, CodexSkillOperationKind::Install);
+        assert!(!fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(fs::read(destination.join("SKILL.md")).unwrap(), b"audit v1");
+        assert_eq!(package_digest_at(&target).unwrap(), target_digest);
+        assert_eq!(
+            inspect_codex_skills(&input).unwrap().statuses[0].state,
+            CodexSkillState::Healthy
+        );
+    }
+
+    #[test]
+    fn apply_replaces_exact_source_symlink_with_existing_ledger() {
+        let temp = TempRoot::new("adopt-source-symlink-ledger");
+        let input = input(&temp, &["audit"], &[], "dev.2");
+        write_skill(&input.assets_skills_root, "audit", "audit v1");
+        let canonical_root = temp.0.join("canonical");
+        write_skill(&canonical_root, "audit", "audit v1");
+
+        let target = canonical_root.join("audit");
+        let destination = input.home.join(".agents").join("skills").join("audit");
+        fs::create_dir_all(destination.parent().unwrap()).unwrap();
+        if !make_dir_symlink(&target, &destination) {
+            return;
+        }
+        let source_digest = package_digest_at(&input.assets_skills_root.join("audit")).unwrap();
+        let target_digest = package_digest_at(&target).unwrap();
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            "audit".into(),
+            CodexSkillsLedgerEntry {
+                digest: source_digest,
+                generation: "dev.1".into(),
+            },
+        );
+        write_ledger(
+            &ledger_path(&input.platform_state_root),
+            &CodexSkillsLedger {
+                schema_version: CODEX_SKILLS_LEDGER_SCHEMA_VERSION,
+                owner: CODEX_SKILLS_OWNER.into(),
+                entries,
+            },
+        )
+        .unwrap();
+
+        let preview = preview_codex_skills(&input).unwrap();
+        assert_eq!(preview.inspection.statuses[0].state, CodexSkillState::Stale);
+        assert_eq!(preview.operations[0].kind, CodexSkillOperationKind::Update);
+
+        let applied = apply_codex_skills(&input).unwrap();
+        assert_eq!(applied.applied.len(), 1);
+        assert_eq!(applied.applied[0].kind, CodexSkillOperationKind::Update);
+        assert!(!fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(package_digest_at(&target).unwrap(), target_digest);
+    }
+
+    #[test]
+    fn mismatched_source_symlink_is_conflict_and_preserved() {
+        let temp = TempRoot::new("mismatched-source-symlink");
+        let input = input(&temp, &["audit"], &[], "dev.1");
+        write_skill(&input.assets_skills_root, "audit", "audit v1");
+        let foreign_root = temp.0.join("foreign");
+        write_skill(&foreign_root, "audit", "user fork");
+
+        let target = foreign_root.join("audit");
+        let destination = input.home.join(".agents").join("skills").join("audit");
+        fs::create_dir_all(destination.parent().unwrap()).unwrap();
+        if !make_dir_symlink(&target, &destination) {
+            return;
+        }
+        let target_digest = package_digest_at(&target).unwrap();
+
+        let preview = preview_codex_skills(&input).unwrap();
+        assert_eq!(
+            preview.inspection.statuses[0].state,
+            CodexSkillState::Conflict
+        );
+        assert!(preview.inspection.statuses[0].destination_digest.is_none());
+        assert!(preview.operations.is_empty());
+
+        let applied = apply_codex_skills(&input).unwrap();
+        assert!(applied.applied.is_empty());
+        assert!(fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(package_digest_at(&target).unwrap(), target_digest);
+    }
+
+    #[test]
+    fn broken_source_symlink_is_conflict_and_preserved() {
+        let temp = TempRoot::new("broken-source-symlink");
+        let input = input(&temp, &["audit"], &[], "dev.1");
+        write_skill(&input.assets_skills_root, "audit", "audit v1");
+
+        let target = temp.0.join("missing").join("audit");
+        let destination = input.home.join(".agents").join("skills").join("audit");
+        fs::create_dir_all(destination.parent().unwrap()).unwrap();
+        if !make_dir_symlink(&target, &destination) {
+            return;
+        }
+        let link_target = fs::read_link(&destination).unwrap();
+
+        let preview = preview_codex_skills(&input).unwrap();
+        assert_eq!(
+            preview.inspection.statuses[0].state,
+            CodexSkillState::Conflict
+        );
+        assert!(preview.operations.is_empty());
+
+        let applied = apply_codex_skills(&input).unwrap();
+        assert!(applied.applied.is_empty());
+        assert!(fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(fs::read_link(&destination).unwrap(), link_target);
+    }
+
+    #[test]
+    fn retired_source_symlink_is_conflict_and_preserved() {
+        let temp = TempRoot::new("retired-source-symlink");
+        let input = input(&temp, &[], &["audit"], "dev.1");
+        let canonical_root = temp.0.join("canonical");
+        write_skill(&canonical_root, "audit", "audit v1");
+
+        let target = canonical_root.join("audit");
+        let destination = input.home.join(".agents").join("skills").join("audit");
+        fs::create_dir_all(destination.parent().unwrap()).unwrap();
+        if !make_dir_symlink(&target, &destination) {
+            return;
+        }
+        let target_digest = package_digest_at(&target).unwrap();
+
+        let preview = preview_remove_codex_skills(&input).unwrap();
+        assert_eq!(
+            preview.inspection.statuses[0].state,
+            CodexSkillState::RetiredConflict
+        );
+        assert!(preview.operations.is_empty());
+
+        let removed = remove_codex_skills(&input).unwrap();
+        assert!(removed.applied.is_empty());
+        assert!(fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(package_digest_at(&target).unwrap(), target_digest);
+    }
+
+    #[test]
+    fn unrelated_user_symlink_is_reported_and_preserved() {
+        let temp = TempRoot::new("unrelated-user-symlink");
+        let input = input(&temp, &["audit"], &[], "dev.1");
+        write_skill(&input.assets_skills_root, "audit", "audit v1");
+        let user_root = temp.0.join("user");
+        write_skill(&user_root, "personal", "personal");
+
+        let target = user_root.join("personal");
+        let destination = input.home.join(".agents").join("skills").join("personal");
+        fs::create_dir_all(destination.parent().unwrap()).unwrap();
+        if !make_dir_symlink(&target, &destination) {
+            return;
+        }
+        let target_digest = package_digest_at(&target).unwrap();
+
+        let preview = preview_codex_skills(&input).unwrap();
+        assert!(preview.inspection.unrelated_paths.contains(&destination));
+        let applied = apply_codex_skills(&input).unwrap();
+        assert!(applied.applied.iter().any(|operation| {
+            operation.id == "audit" && operation.kind == CodexSkillOperationKind::Install
+        }));
+        assert!(fs::symlink_metadata(&destination)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(package_digest_at(&target).unwrap(), target_digest);
     }
 
     #[test]
@@ -1398,6 +1687,7 @@ mod tests {
             &stage,
             true,
             Some(&expected),
+            None,
             &ledger_path,
             &ledger,
         )

--- a/engine/crates/legion-host/src/error.rs
+++ b/engine/crates/legion-host/src/error.rs
@@ -93,7 +93,7 @@ impl Display for HostError {
             ),
             Self::ReleaseBindingMismatch { reason } => write!(
                 formatter,
-                "RELEASE_BINDING_MISMATCH: {reason}; run legion setup --repair"
+                "RELEASE_BINDING_MISMATCH: {reason}; run legion setup repair --confirm"
             ),
             Self::Verification { reason } => write!(formatter, "VERIFICATION_FAILED: {reason}"),
             Self::Rollback { reason } => write!(formatter, "ROLLBACK_FAILED: {reason}"),

--- a/engine/crates/legion-host/src/setup_registry.rs
+++ b/engine/crates/legion-host/src/setup_registry.rs
@@ -311,7 +311,7 @@ impl SetupStore for OnDiskSetupStore {
         let state = serde_json::from_slice(&read(&self.state)?).map_err(|_| {
             err(
                 SetupErrorCode::StateMetadataInvalid,
-                "setup state is corrupt; run legion setup --repair",
+                "setup state is corrupt; run legion setup repair --confirm",
             )
         })?;
         Ok(Some(state))
@@ -475,7 +475,7 @@ impl<S: SetupStore> SetupRegistry<S> {
         let journal: Journal = serde_json::from_slice(&read(&path)?).map_err(|_| {
             err(
                 SetupErrorCode::JournalIncomplete,
-                "interrupted setup journal is invalid; run legion setup --repair",
+                "interrupted setup journal is invalid; run legion setup repair --confirm",
             )
         })?;
         let lock = self.store.acquire_exclusive_lock()?;
@@ -987,7 +987,7 @@ fn validate_release(release: &BoundRelease) -> Result<(), SetupError> {
     {
         Err(err(
             SetupErrorCode::ReleaseBindingMismatch,
-            "release binding is incomplete; run legion setup --repair",
+            "release binding is incomplete; run legion setup repair --confirm",
         ))
     } else {
         Ok(())
@@ -1039,7 +1039,7 @@ fn detected(evidence: &ClientEvidence) -> DetectedClient {
         remediation: if qualified {
             Vec::new()
         } else {
-            vec!["legion setup --repair".into()]
+            vec!["legion setup repair --confirm".into()]
         },
     }
 }

--- a/engine/crates/legion-runtime/src/release_binding.rs
+++ b/engine/crates/legion-runtime/src/release_binding.rs
@@ -9,7 +9,7 @@ use legion_catalog::json;
 use serde::{Deserialize, Serialize};
 
 /// The sole remediation for a mixed or otherwise invalid installed identity.
-pub const REPAIR_COMMAND: &str = "legion setup --repair";
+pub const REPAIR_COMMAND: &str = "legion setup repair --confirm";
 pub const CANONICAL_RELEASE_MANIFEST: &str = "share/legion/release.json";
 pub const RIGHTKIT_AX_VERSION: &str = "0.2.0";
 pub const RIGHTKIT_AX_SOURCE_COMMIT: &str = "01f52555202da3dffc6b649ca44e803b55238081";
@@ -608,7 +608,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(component, "state schema version");
-                assert_eq!(remediation, "legion setup --repair");
+                assert_eq!(remediation, "legion setup repair --confirm");
             }
             error => panic!("wrong error: {error:?}"),
         }

--- a/engine/tests/m2_portable_integration.rs
+++ b/engine/tests/m2_portable_integration.rs
@@ -196,7 +196,7 @@ fn reference_clients_have_identical_bound_identity_and_fail_closed_on_skew() {
     skewed.mcp_tool_schema_hash = "sha256:stale".into();
     let error = verify_client_identity(&claude, &skewed, &resolution("claude-code")).unwrap_err();
     assert_eq!(error.code(), FailureCode::ReleaseBindingMismatch);
-    assert!(error.to_string().contains("legion setup --repair"));
+    assert!(error.to_string().contains("legion setup repair --confirm"));
 
     assert_eq!(
         ClientFidelity::from_evidence(true, false, false, false, false),

--- a/migration/native-rust/PRODUCT-ARCHITECTURE-V2.md
+++ b/migration/native-rust/PRODUCT-ARCHITECTURE-V2.md
@@ -185,7 +185,7 @@ Every installed integration binds its assets to one Legion release using at leas
 - declarative-asset/schema hash.
 
 MCP initialization verifies binding before exposing tools. Mismatch fails closed with exact
-`legion setup --repair` remediation; stale assets never run silently against a newer runtime.
+`legion setup repair --confirm` remediation; stale assets never run silently against a newer runtime.
 Package-manager update and integration refresh may form a bounded skew window, but no mixed-version
 execution is allowed: setup repairs each integration transactionally after update. Existing client
 processes may finish under their bound release; incompatible state migration waits for old runtime

--- a/migration/native-rust/dispatches/windows-closure/packet.json
+++ b/migration/native-rust/dispatches/windows-closure/packet.json
@@ -1,0 +1,151 @@
+{
+  "schemaVersion": 1,
+  "kind": "legion-authority-dispatch",
+  "packetType": "direct",
+  "repositoryRoot": "D:/Claude/legion",
+  "sourceRevision": "445d85f87793fcc4978709b7c473e927db8f4d8a",
+  "sourceArtifact": "migration/native-rust/dispatches/windows-closure/prompt.md",
+  "promptArtifact": "migration/native-rust/dispatches/windows-closure/prompt.md",
+  "promptDigest": "sha256:89a0e7fa54b81541eb2ec0d4ee7d61afde090b8b6bcd48123e3eb985ec61133f",
+  "modelRouting": {
+    "modelTier": "MID",
+    "workerProfile": "luna-max",
+    "routingRationale": "Three disjoint bounded Windows implementation lanes requested for maximum safe parallelism"
+  },
+  "objective": "Implement source-only Windows closure seams for strong native hooks, truthful/safe live-client reconciliation, & release/WinGet packaging; leave every build, test, generator, install, signing action, commit, push, merge, & expensive check to current orchestrator.",
+  "authority": [
+    "AGENTS.md",
+    "migration/native-rust/dispatches/windows-closure/prompt.md",
+    "docs/LEGION-CANONICAL-SSOT.md",
+    "packaging/windows/sign.md"
+  ],
+  "integrationOwner": "current orchestrator /root",
+  "fileTouchPolicy": {
+    "mode": "once-end-to-end",
+    "plannedFiles": [
+      "engine/bins/legion-hook/Cargo.toml",
+      "engine/bins/legion-hook/src/main.rs",
+      "engine/bins/legion-hook/src/protocol.rs",
+      "engine/bins/legion/src/commands/setup.rs",
+      "engine/bins/legion/tests/m2_plugin_root.rs",
+      "right-release.config.mjs",
+      "scripts/assemble-native-release.mjs",
+      "scripts/package-windows-release.mjs",
+      "tests/release-artifacts.test.mjs",
+      "package.json",
+      "packaging/windows/sign.md"
+    ],
+    "allowUnplannedFiles": false,
+    "ledger": [
+      {"path":"engine/bins/legion-hook/Cargo.toml","owner":"windows-native-hooks","operation":"edit","lane":"windows-native-hooks","finalCheck":"orchestrator Cargo check/test & live hook smoke"},
+      {"path":"engine/bins/legion-hook/src/main.rs","owner":"windows-native-hooks","operation":"edit","lane":"windows-native-hooks","finalCheck":"orchestrator Cargo check/test & live hook smoke"},
+      {"path":"engine/bins/legion-hook/src/protocol.rs","owner":"windows-native-hooks","operation":"edit","lane":"windows-native-hooks","finalCheck":"orchestrator Cargo check/test & live hook smoke"},
+      {"path":"engine/bins/legion/src/commands/setup.rs","owner":"windows-live-repair","operation":"edit","lane":"windows-live-repair","finalCheck":"orchestrator focused Rust tests & isolated/live setup status/repair smoke"},
+      {"path":"engine/bins/legion/tests/m2_plugin_root.rs","owner":"windows-live-repair","operation":"edit","lane":"windows-live-repair","finalCheck":"orchestrator focused Rust test"},
+      {"path":"right-release.config.mjs","owner":"windows-release-package","operation":"edit","lane":"windows-release-package","finalCheck":"orchestrator right-release doctor"},
+      {"path":"scripts/assemble-native-release.mjs","owner":"windows-release-package","operation":"edit","lane":"windows-release-package","finalCheck":"orchestrator Node test & release assembly"},
+      {"path":"scripts/package-windows-release.mjs","owner":"windows-release-package","operation":"create","lane":"windows-release-package","finalCheck":"orchestrator Node test & package verification"},
+      {"path":"tests/release-artifacts.test.mjs","owner":"windows-release-package","operation":"edit","lane":"windows-release-package","finalCheck":"orchestrator focused Node test"},
+      {"path":"package.json","owner":"windows-release-package","operation":"edit","lane":"windows-release-package","finalCheck":"orchestrator package scripts & legion:check"},
+      {"path":"packaging/windows/sign.md","owner":"windows-release-package","operation":"edit","lane":"windows-release-package","finalCheck":"orchestrator static release contract check"}
+    ]
+  },
+  "sourcePortPolicy": {
+    "applicable": true,
+    "sourceImplementation": "src/packages/arcane/host/hook-adapter-core.mjs",
+    "sourceInventory": [
+      "src/packages/arcane/host/hook-adapter-core.mjs",
+      "src/packages/arcane/tests/hook-adapter-core.test.mjs",
+      "engine/crates/legion-policy/src/evaluator.rs",
+      "engine/crates/legion-host/src/codex_skills.rs",
+      "engine/crates/legion-host/src/legacy_claude.rs",
+      "scripts/verify-release.mjs",
+      "release/distribution-contract.json",
+      "packaging/channels.json"
+    ],
+    "directPortFirst": true,
+    "targetLanguage": "Rust for native behavior; JavaScript for release packaging",
+    "rustTargetRequiresRustPort": true,
+    "handRollReplacementWhileSourceExists": false
+  },
+  "workerPolicy": {
+    "mode": "edit-only",
+    "mayInspectReadPaths": true,
+    "mayEditAllowlistOnly": true,
+    "forbiddenActions": ["cargo","tests","builds","generators","installs","commits","pushes","merges","expensive-checks"],
+    "intendedChecksRecordedFor": "current orchestrator /root"
+  },
+  "integrationPolicy": {
+    "owner": "current orchestrator /root",
+    "soleMerger": true,
+    "runsCheckpoints": true,
+    "mayRepairLaneOwnedFiles": false,
+    "repairAction": "return defect to owning lane once; otherwise redesign packet before execution"
+  },
+  "dispatches": [
+    {
+      "id": "A",
+      "dependsOn": [],
+      "lanes": ["windows-native-hooks","windows-live-repair","windows-release-package"],
+      "completionChecks": ["orchestrator reconciles exact changed paths, runs all focused checks/builds/install smoke, & owns final evidence"]
+    }
+  ],
+  "workers": [
+    {
+      "id": "windows-native-hooks",
+      "dispatch": "A",
+      "executor": "Luna max worker",
+      "allowlist": ["engine/bins/legion-hook/Cargo.toml","engine/bins/legion-hook/src/main.rs","engine/bins/legion-hook/src/protocol.rs"],
+      "read": ["migration/native-rust/dispatches/windows-closure/prompt.md","src/packages/arcane/host/hook-adapter-core.mjs","src/packages/arcane/tests/hook-adapter-core.test.mjs","engine/crates/legion-policy/src/evaluator.rs","engine/crates/legion-policy/src/lib.rs","engine/crates/legion-policy-model/src/lib.rs","hooks/hooks.json"],
+      "forbidden": [".git","secrets","live client directories","release/distribution-contract.json","packaging/channels.json"],
+      "checks": ["orchestrator runs cargo fmt/check/test for legion-hook & live valid/invalid hook smoke; worker runs no check"],
+      "dependencies": []
+    },
+    {
+      "id": "windows-live-repair",
+      "dispatch": "A",
+      "executor": "Luna max worker",
+      "allowlist": ["engine/bins/legion/src/commands/setup.rs","engine/bins/legion/tests/m2_plugin_root.rs"],
+      "read": ["migration/native-rust/dispatches/windows-closure/prompt.md","engine/crates/legion-host/src/codex_skills.rs","engine/crates/legion-host/src/legacy_claude.rs","engine/crates/legion-host/src/setup_registry.rs","engine/crates/legion-runtime/src/release_binding.rs","engine/assets/legion-plugin/plugin.json"],
+      "forbidden": [".git","secrets","live client directories"],
+      "checks": ["orchestrator runs focused m2_plugin_root/setup tests plus isolated & live status/repair smoke; worker runs no check"],
+      "dependencies": []
+    },
+    {
+      "id": "windows-release-package",
+      "dispatch": "A",
+      "executor": "Luna max worker",
+      "allowlist": ["right-release.config.mjs","scripts/assemble-native-release.mjs","scripts/package-windows-release.mjs","tests/release-artifacts.test.mjs","package.json","packaging/windows/sign.md"],
+      "read": ["migration/native-rust/dispatches/windows-closure/prompt.md","scripts/verify-release.mjs","release/distribution-contract.json","release/publication-policy.json","packaging/channels.json","migration/native-rust/m0/distribution-contract.json","node_modules/@rightkit/release/release.mjs"],
+      "forbidden": [".git","secrets",".github/workflows/ci.yml"],
+      "checks": ["orchestrator runs focused release Node test, right-release doctor, x64/ARM64 assembly/package verification, signing smoke when credentials exist, & legion:check; worker runs no check"],
+      "dependencies": []
+    }
+  ],
+  "oracleAudit": {
+    "required": true,
+    "mode": "adversarial",
+    "status": "required-before-execution",
+    "checks": ["allowlist-completeness","lane-disjointness","dependency-validity","maximum-safe-parallelization","end-to-end-lane-closure","direct-port-priority","worker-edit-only","integration-owner-checkpoints","exact-byte-review-pass"]
+  },
+  "recovery": {
+    "maxRetries": 2,
+    "stopConditions": ["owned path is dirty before worker edit","required source input missing","allowlist proves insufficient","private signing input required during source-only lane"],
+    "returnFields": ["changedPaths","checks","blockers","baselineRevision","patchDigest"],
+    "failureClasses": {
+      "missingPathOrInput": "re-read exact path, inspect declared read inventory, stop after second absence",
+      "missingToolOrDependency": "source-only lane records intended orchestrator check & continues without installing",
+      "authOrPermission": "not applicable to source-only lane; do not access secrets or external services",
+      "transientExternal": "not applicable; external calls forbidden",
+      "invalidSchemaOrInput": "inspect canonical schema/source & make one bounded correction within allowlist",
+      "integrityMismatch": "stop without editing & return exact digest mismatch",
+      "deterministicFailure": "workers do not run checks; record predicted failing check for orchestrator",
+      "dirtyConflict": "stop immediately on owned-path dirtiness & report exact path",
+      "wrongProvenance": "stop & report source revision/digest mismatch",
+      "resourceCapacity": "stop broad work; return partial exact diff only if every changed path is allowlisted",
+      "ambiguousRequirement": "use smallest fail-closed behavior from prompt; otherwise TRUE_BLOCKER with one non-inferable decision",
+      "unsafeOrOutOfScope": "do not act; continue independent allowlisted work",
+      "unknown": "re-read raw error once, retry smallest read once, then return TRUE_BLOCKER evidence"
+    }
+  }
+}

--- a/migration/native-rust/dispatches/windows-closure/packet.json
+++ b/migration/native-rust/dispatches/windows-closure/packet.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "kind": "legion-authority-dispatch",
   "packetType": "direct",
-  "repositoryRoot": "D:/Claude/legion",
+  "repositoryRoot": "<repository-root>",
   "sourceRevision": "445d85f87793fcc4978709b7c473e927db8f4d8a",
   "sourceArtifact": "migration/native-rust/dispatches/windows-closure/prompt.md",
   "promptArtifact": "migration/native-rust/dispatches/windows-closure/prompt.md",
-  "promptDigest": "sha256:89a0e7fa54b81541eb2ec0d4ee7d61afde090b8b6bcd48123e3eb985ec61133f",
+  "promptDigest": "sha256:26f40beaf5c38114cbdd458f6ad05d28938d1aef076086ebf29a542b3f648144",
   "modelRouting": {
     "modelTier": "MID",
     "workerProfile": "luna-max",

--- a/migration/native-rust/dispatches/windows-closure/prompt.md
+++ b/migration/native-rust/dispatches/windows-closure/prompt.md
@@ -6,7 +6,7 @@ Remove development suffix from Legion version. Close Windows work only; Apple/ma
 
 ## Frozen facts
 
-- Repository: `D:/Claude/legion`
+- Repository: `<repository-root>`
 - Baseline: `445d85f87793fcc4978709b7c473e927db8f4d8a`
 - Canonical version: `0.1.0`; baseline is clean & synchronized with `origin/main`.
 - CI run `33119242090` passed Ubuntu, Windows, macOS, & private-repo guard.

--- a/migration/native-rust/dispatches/windows-closure/prompt.md
+++ b/migration/native-rust/dispatches/windows-closure/prompt.md
@@ -1,0 +1,24 @@
+# Windows closure authority
+
+## Raw operator scope
+
+Remove development suffix from Legion version. Close Windows work only; Apple/macOS release work is explicitly out of this pass because it is configured on Mac. Finish Windows-native behavior, stable artifact production, live Windows install, Codex/Claude wiring, hooks, & WinGet readiness. Preserve user-owned skills/private data. Workers must never run Cargo, builds, tests, generators, installs, commits, pushes, merges, or heavy checks; current orchestrator owns every such action.
+
+## Frozen facts
+
+- Repository: `D:/Claude/legion`
+- Baseline: `445d85f87793fcc4978709b7c473e927db8f4d8a`
+- Canonical version: `0.1.0`; baseline is clean & synchronized with `origin/main`.
+- CI run `33119242090` passed Ubuntu, Windows, macOS, & private-repo guard.
+- Live Windows binaries remain stale `0.1.0-dev.3` until orchestrator builds & installs stable output.
+- `legion-hook` currently returns `enforcementHealth: unsupported` for valid requests.
+- Codex & Claude live projections/cache are stale; repair must preserve unrelated user-owned directories.
+- Windows signing environment currently lacks `signtool.exe`, `winget.exe`, `ARTIFACT_SIGNING_DLIB`, `ARTIFACT_SIGNING_METADATA`, & Azure signing variables.
+- `@rightkit/release` `0.2.68` is current npm latest; its doctor rejects every hosted workflow, including right-git-managed `.github/workflows/ci.yml`. Cross-repository RightKit repair is owned by orchestrator, not these lanes.
+
+## Acceptance owned by orchestrator
+
+1. Valid hook requests receive a real deterministic policy result with strong enforcement; invalid frames fail closed.
+2. Setup status & repair observe live executable/plugin/projection identity, refresh owned stale artifacts, remove only proven retired Legion projections, & preserve unrelated user data.
+3. Windows release config supports explicit x86_64 & ARM64 artifacts, packaging, signing inputs, checksums, SBOM/notices/provenance/qualification references, & WinGet portable metadata without claiming signed/available before evidence exists.
+4. Orchestrator runs all focused tests, Cargo checks/builds, release doctor/package verification, live install/repair, client/hook smoke checks, commits, pushes, CI, audit, & Oracle completion validation.

--- a/migration/native-rust/m0/agent-plugins-contract.json
+++ b/migration/native-rust/m0/agent-plugins-contract.json
@@ -124,7 +124,7 @@
     ],
     "failure": {
       "behavior": "fail closed",
-      "remediation": "legion setup --repair",
+      "remediation": "legion setup repair --confirm",
       "forbidden": "silent mixed-version execution"
     }
   },

--- a/migration/native-rust/m0/distribution-contract.json
+++ b/migration/native-rust/m0/distribution-contract.json
@@ -15,7 +15,7 @@
     "futureUnqualifiedAlias": "brew install legion",
     "artifacts": ["arm64 macOS bottle", "x86_64 macOS bottle"],
     "requirements": ["Developer ID signature", "Apple notarization", "stapled notarization evidence where applicable", "SHA-256 bottle digest", "release provenance", "legion command on Homebrew prefix PATH"],
-    "update": "brew upgrade legion followed transactionally by legion setup --repair",
+    "update": "brew upgrade legion followed transactionally by legion setup repair --confirm",
     "rollback": "reinstall the preceding immutable bottle, restore the matching state snapshot, then repair integrations to the preceding release binding",
     "removal": "brew uninstall legion removes the runtime; legion setup remove handles integrations; durable state is preserved unless explicit verified purge is requested"
   },
@@ -26,7 +26,7 @@
     "installCommand": "winget install --id OrthicLabs.Legion --exact",
     "requirements": ["Authenticode signature", "trusted timestamp", "SHA-256 installer digest", "legion command alias", "silent upgrade", "deterministic uninstall", "release provenance"],
     "fallbackDisposition": "If WinGet portable cannot preserve signature verification, command aliases, update, and removal, M3 must select an archive-based package manifest with the same guarantees; no MSI or desktop installer is introduced.",
-    "update": "winget upgrade --id OrthicLabs.Legion --exact followed transactionally by legion setup --repair",
+    "update": "winget upgrade --id OrthicLabs.Legion --exact followed transactionally by legion setup repair --confirm",
     "rollback": "install the preceding immutable signed version, restore the matching state snapshot, then repair integrations to the preceding release binding",
     "removal": "winget uninstall --id OrthicLabs.Legion --exact removes the runtime; integrations and explicit state purge remain separate legion setup operations"
   },

--- a/migration/native-rust/m0/release-binding-contract.json
+++ b/migration/native-rust/m0/release-binding-contract.json
@@ -18,13 +18,13 @@
     "phase": "MCP initialization before exposing any Legion tool",
     "checks": ["runtime digest and provenance", "release version", "capability catalog hash", "MCP schema hash", "declarative asset hash", "state compatibility"],
     "success": "Expose tools with the exact bound release identity.",
-    "failure": "Fail closed without exposing tools and emit exact legion setup --repair remediation."
+    "failure": "Fail closed without exposing tools and emit exact legion setup repair --confirm remediation."
   },
   "skewPolicy": {
     "allowed": "A bounded package-manager update window while no mixed-version execution occurs.",
     "forbidden": "New runtime with stale integration assets, schemas, catalog, or tool contracts.",
     "activeProcesses": "Existing client-owned processes may finish under their bound release; incompatible state migration waits for old runtime leases to close.",
-    "repair": "legion setup --repair refreshes every selected integration transactionally and verifies the complete identity tuple before activation."
+    "repair": "legion setup repair --confirm refreshes every selected integration transactionally and verifies the complete identity tuple before activation."
   },
   "updateTransaction": ["verify new signed runtime", "snapshot compatible durable state", "install runtime and versioned assets", "repair selected integrations", "verify binding handshake", "activate or roll back atomically"],
   "rollbackTransaction": ["wait for incompatible active leases", "restore preceding signed runtime", "restore preceding state snapshot", "restore matching integration assets", "verify binding handshake", "reactivate preceding release"],

--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
     "plugin:verify": "node scripts/verify-plugin-parity.mjs --check",
     "plugin:dev": "node scripts/plugin-dev.mjs",
     "native:assemble": "node scripts/assemble-native-release.mjs",
+    "windows:package": "node scripts/package-windows-release.mjs",
+    "release:doctor": "right-release doctor --platform win",
     "biome": "biome lint . --max-diagnostics=1000",
     "biome:check": "biome lint . --max-diagnostics=1000"
   },
@@ -124,6 +126,6 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.10",
     "@rightkit/git": "0.2.1",
-    "@rightkit/release": "0.2.68"
+    "@rightkit/release": "0.2.70"
   }
 }

--- a/packaging/windows/sign.md
+++ b/packaging/windows/sign.md
@@ -1,5 +1,26 @@
-# Windows signing pipeline per SNIP-WIN-SIGN-01.
+# Windows signing contract: windows-raw-exe-authenticode-before-portable-v1.
 # Uses Microsoft Artifact Signing/SignTool with RFC3161 timestamping.
+
+## Target identity
+
+Each invocation must select exactly one target. The archive name, release
+identity, signing receipt, and WinGet architecture must agree:
+
+| Legion architecture | Cargo target | WinGet architecture | signed file |
+| --- | --- | --- | --- |
+| `x86_64` | `x86_64-pc-windows-msvc` | `x64` | `bin\legion.exe` |
+| `arm64` | `aarch64-pc-windows-msvc` | `arm64` | `bin\legion.exe` |
+
+Never infer target identity from a host architecture or a filename. All three
+raw EXEs are fully patched before signing, then copied byte-for-byte into the
+portable ZIP. A receipt is valid only when it records exactly three files with
+`Authenticode: Valid`, subject `CN=Damned Ventures LLC`, a trusted timestamp,
+and each final SHA-256.
+
+Signing inputs use canonical `sign-windows.mjs` environment names:
+`AZURE_ARTIFACT_SIGNING_DLIB_PATH`, `AZURE_ARTIFACT_SIGNING_METADATA`,
+`AZURE_ARTIFACT_SIGNING_ENDPOINT`, `AZURE_ARTIFACT_SIGNING_ACCOUNT`, and
+`AZURE_ARTIFACT_SIGNING_PROFILE`.
 
 name: Legion Windows signing
 
@@ -11,13 +32,39 @@ steps:
         /fd SHA256 `
         /tr "http://timestamp.acs.microsoft.com" `
         /td SHA256 `
-        /dlib "$env:ARTIFACT_SIGNING_DLIB" `
-        /dmdf "$env:ARTIFACT_SIGNING_METADATA" `
-        "dist\legion.exe"
+        /dlib "$env:AZURE_ARTIFACT_SIGNING_DLIB_PATH" `
+        /dmdf "$env:AZURE_ARTIFACT_SIGNING_METADATA" `
+        "dist\native\windows-x86_64\legion-<version>\bin\legion.exe"
   - name: Verify
-    run: signtool.exe verify /pa /all /v "dist\legion.exe"
+    run: signtool.exe verify /pa /all /v "dist\native\windows-x86_64\legion-<version>\bin\legion.exe"
+
+For ARM64, run same two steps against
+`dist\native\windows-arm64\legion-<version>\bin\legion.exe` & select the
+`aarch64-pc-windows-msvc` target at assembly time.
+
+receipt:
+  path: .right-release/receipts/windows-<architecture>-raw-exe.json
+  requiredFields: [schema, files, file, after.sha256, authenticode, subject, timestampPresent]
+  requiredFileCount: 3
+  requiredValues:
+    schema: 1
+    authenticode: Valid
+    subject: "CN=Damned Ventures LLC"
+    timestampPresent: true
+
+portablePackage:
+  command: pnpm windows:package -- --architecture x86_64 --signature-receipt .right-release/receipts/windows-x86_64-raw-exe.json --require-signature
+  alternateCommand: pnpm windows:package -- --architecture arm64 --signature-receipt .right-release/receipts/windows-arm64-raw-exe.json --require-signature
+  archive: legion-<version>-windows-<architecture>.zip
+  channel: BLOCKED_UNTIL_QUALIFIED
+
+failClosed:
+  - "Missing signtool.exe, Azure signing client, metadata, identity, or timestamp fails the step."
+  - "A missing, stale, invalid, or digest-mismatched receipt never becomes signed evidence."
+  - "Unsigned/local-build provenance remains blocked and cannot produce a publication grant."
+  - "WinGet metadata is emitted as blocked evidence until installed-product qualification and channel authorization exist."
 
 documentation:
   - "The release job must use the current Microsoft Artifact Signing integration metadata."
   - "Verify the downloaded final artifact, not only the pre-upload path."
-  - "Bind the signed digest to the release attestation."
+  - "Bind the signed digest, target triple, provenance, and qualification receipt to the release manifest."

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: 0.2.1
         version: 0.2.1(patch_hash=8d2d62ccdeeb6cd64c43965900b6c56a984da2e98d6d47cb00848c8aeba27bac)
       '@rightkit/release':
-        specifier: 0.2.68
-        version: 0.2.68
+        specifier: 0.2.70
+        version: 0.2.70
 
 packages:
 
@@ -92,8 +92,8 @@ packages:
     resolution: {integrity: sha512-Z8AOe4eRJN90k98D9DB6XgKjSmjNTeQNcpHuTBIJRk0xmFyO7jqzV9AmO7jxFJOSg9YkzEuftra0UhfYLbGXRA==}
     hasBin: true
 
-  '@rightkit/release@0.2.68':
-    resolution: {integrity: sha512-oIo4AYNJ+9l92ED6D++tHA63j7mA7hGTFARmzu2As7pa3gaPj82JaZDd6ceOkjHZOcX9FFzKTUn+hPdSuutwNA==}
+  '@rightkit/release@0.2.70':
+    resolution: {integrity: sha512-OUrKPV9abM56iQsaCfqh/rU6p5G6dNwvT5YkZ3sqKvRFpBMsCvguwWyyLDkpsLC9GyCJUDAMmSpwCgm3TV92bw==}
     hasBin: true
 
 snapshots:
@@ -137,4 +137,4 @@ snapshots:
 
   '@rightkit/hooks@0.1.1': {}
 
-  '@rightkit/release@0.2.68': {}
+  '@rightkit/release@0.2.70': {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 minimumReleaseAgeExclude:
   - '@rightkit/hooks@0.1.0 || 0.1.1'
   - '@rightkit/git@0.2.1'
-  - '@rightkit/release@0.2.68'
+  - '@rightkit/release@0.2.70'
 patchedDependencies:
   '@rightkit/git@0.2.1': patches/@rightkit__git@0.2.1.patch

--- a/right-release.config.mjs
+++ b/right-release.config.mjs
@@ -1,6 +1,52 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const releaseVersion = JSON.parse(
+	readFileSync(fileURLToPath(new URL("./release/version.json", import.meta.url)), "utf8"),
+).version;
+
+/**
+ * Windows release identity is intentionally explicit. The package script
+ * accepts only these two entries and binds every archive to its Cargo target
+ * triple, WinGet architecture, and executable name.
+ */
+export const WINDOWS_ARCHITECTURES = Object.freeze({
+	x86_64: Object.freeze({
+		platform: "windows",
+		architecture: "x86_64",
+		wingetArchitecture: "x64",
+		targetTriple: "x86_64-pc-windows-msvc",
+		artifactId: "windows-x86_64",
+		assemblyRoot: `dist/native/windows-x86_64/legion-${releaseVersion}`,
+		archive: `legion-${releaseVersion}-windows-x86_64.zip`,
+	}),
+	arm64: Object.freeze({
+		platform: "windows",
+		architecture: "arm64",
+		wingetArchitecture: "arm64",
+		targetTriple: "aarch64-pc-windows-msvc",
+		artifactId: "windows-arm64",
+		assemblyRoot: `dist/native/windows-arm64/legion-${releaseVersion}`,
+		archive: `legion-${releaseVersion}-windows-arm64.zip`,
+	}),
+});
+
+const windowsX64 = WINDOWS_ARCHITECTURES.x86_64;
+const windowsArm64 = WINDOWS_ARCHITECTURES.arm64;
+const selectedArchitecture = String(process.env.LEGION_WINDOWS_ARCH ?? "x86_64").trim().toLowerCase();
+if (!WINDOWS_ARCHITECTURES[selectedArchitecture]) {
+	throw new Error(`unsupported LEGION_WINDOWS_ARCH: ${selectedArchitecture}; expected x86_64 or arm64`);
+}
+const selectedWindows = WINDOWS_ARCHITECTURES[selectedArchitecture];
+const selectedOutput = `dist/releases/windows/${releaseVersion}/${selectedWindows.architecture}`;
+const selectedReceipt = `.right-release/receipts/windows-${selectedWindows.architecture}-raw-exe.json`;
+const selectedProvenance = `.right-release/receipts/windows-${selectedWindows.architecture}-provenance.json`;
+const selectedQualification = `.right-release/receipts/windows-${selectedWindows.architecture}-qualification.json`;
+
 export default {
 	schema: 1,
 	app: "legion",
+	hostedWorkflows: "right-git-ci-only",
 	version: "release/version.json",
 	packageManager: "pnpm@11.24.0",
 	workdir: ".",
@@ -11,7 +57,10 @@ export default {
 			"skills/**",
 			"src/registry/**",
 			"scripts/assemble-native-release.mjs",
+			"scripts/package-windows-release.mjs",
 			"release/**",
+			"packaging/windows/sign.md",
+			"docs/THIRD_PARTY_NOTICES.md",
 			"package.json",
 			"pnpm-lock.yaml",
 		],
@@ -21,6 +70,7 @@ export default {
 		defaultProfile: "release",
 		localProvenanceScheme: "local-build",
 		signedProvenanceScheme: "rightkit-release",
+		targetArchitectures: WINDOWS_ARCHITECTURES,
 		packageHook: {
 			cmd: "pnpm",
 			args: ["native:assemble", "--", "--profile", "release"],
@@ -28,9 +78,110 @@ export default {
 	},
 	targets: {
 		win: {
-			signed: false,
-			publishBlocked: "native signing, provenance, and channel authorization are incomplete",
-			package: { cmd: "pnpm", args: ["native:assemble", "--", "--profile", "release"] },
+			// Portable RightKit signing is enabled, but publication remains blocked
+			// until every raw EXE has a matching verified receipt & qualification.
+			signed: true,
+			platform: "windows",
+			packageKind: "portable-zip",
+			packageManager: "winget",
+			defaultArchitecture: "x86_64",
+			selectedArchitecture,
+			architectures: WINDOWS_ARCHITECTURES,
+			requiredArchitectures: ["x86_64", "arm64"],
+			signingContract: "windows-raw-exe-authenticode-before-portable-v1",
+			publishBlocked: "Windows channel blocked until both architecture artifacts have real Authenticode, provenance, qualification, and channel evidence",
+			prePackage: {
+				cmd: "pnpm",
+				args: [
+					"native:assemble",
+					"--",
+					"--profile",
+					"release",
+					"--platform",
+					"windows",
+					"--architecture",
+					selectedWindows.architecture,
+					"--target",
+					selectedWindows.targetTriple,
+					"--out",
+					selectedWindows.assemblyRoot,
+					"--force",
+				],
+			},
+			sign: {
+				// These are evidence seams, not permission to bypass signing. The
+				// release remains blocked while these paths lack a Valid receipt.
+				prePackageFiles: [
+					`${selectedWindows.assemblyRoot}/bin/legion.exe`,
+					`${selectedWindows.assemblyRoot}/bin/legion-hook.exe`,
+					`${selectedWindows.assemblyRoot}/bin/legion-mcp.exe`,
+				],
+				receipt: selectedReceipt,
+				requiredEnvironment: [
+					"AZURE_ARTIFACT_SIGNING_DLIB_PATH",
+					"AZURE_ARTIFACT_SIGNING_METADATA",
+					"AZURE_ARTIFACT_SIGNING_ENDPOINT",
+					"AZURE_ARTIFACT_SIGNING_ACCOUNT",
+					"AZURE_ARTIFACT_SIGNING_PROFILE",
+				],
+			},
+			evidence: {
+				signature: selectedReceipt,
+				provenance: selectedProvenance,
+				qualification: selectedQualification,
+				artifacts: ["SHA256SUMS", "SBOM.cdx.json", "THIRD_PARTY_NOTICES.md", "winget-portable.json"],
+			},
+			package: {
+				cmd: "pnpm",
+				args: [
+					"windows:package",
+					"--",
+					"--architecture",
+					selectedWindows.architecture,
+					"--input",
+					selectedWindows.assemblyRoot,
+					"--signature-receipt",
+					selectedReceipt,
+					"--provenance",
+					selectedProvenance,
+					"--qualification",
+					selectedQualification,
+					"--output",
+					selectedOutput,
+					"--require-signature",
+				],
+			},
+			packageMatrix: [
+				{
+					platform: windowsX64.platform,
+					architecture: windowsX64.architecture,
+					wingetArchitecture: windowsX64.wingetArchitecture,
+					targetTriple: windowsX64.targetTriple,
+					input: windowsX64.assemblyRoot,
+					output: `dist/releases/windows/${releaseVersion}/x86_64`,
+					archive: windowsX64.archive,
+					receipt: `.right-release/receipts/windows-${windowsX64.architecture}-raw-exe.json`,
+					provenance: `.right-release/receipts/windows-${windowsX64.architecture}-provenance.json`,
+					qualification: `.right-release/receipts/windows-${windowsX64.architecture}-qualification.json`,
+					artifact: `dist/releases/windows/${releaseVersion}/x86_64/${windowsX64.archive}`,
+				},
+				{
+					platform: windowsArm64.platform,
+					architecture: windowsArm64.architecture,
+					wingetArchitecture: windowsArm64.wingetArchitecture,
+					targetTriple: windowsArm64.targetTriple,
+					input: windowsArm64.assemblyRoot,
+					output: `dist/releases/windows/${releaseVersion}/arm64`,
+					archive: windowsArm64.archive,
+					receipt: `.right-release/receipts/windows-${windowsArm64.architecture}-raw-exe.json`,
+					provenance: `.right-release/receipts/windows-${windowsArm64.architecture}-provenance.json`,
+					qualification: `.right-release/receipts/windows-${windowsArm64.architecture}-qualification.json`,
+					artifact: `dist/releases/windows/${releaseVersion}/arm64/${windowsArm64.archive}`,
+				},
+			],
+			artifacts: [
+				`${selectedOutput}/${selectedWindows.archive}`,
+			],
 		},
 		mac: {
 			signed: false,

--- a/scripts/assemble-native-release.mjs
+++ b/scripts/assemble-native-release.mjs
@@ -17,9 +17,69 @@ import rightReleaseConfig from "../right-release.config.mjs";
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const releaseVersionRecord = join(repositoryRoot, "release", "version.json");
 
+/**
+ * The Windows target names are part of the release identity.  Do not infer an
+ * ARM64 artifact from the host process architecture: a cross build must name
+ * its target explicitly, otherwise a valid x64 binary can be published under
+ * an ARM64 filename (or vice versa).
+ */
+export const WINDOWS_TARGETS = Object.freeze({
+	x86_64: Object.freeze({
+		platform: "windows",
+		architecture: "x86_64",
+		installerArchitecture: "x64",
+		targetTriple: "x86_64-pc-windows-msvc",
+		executableSuffix: ".exe",
+	}),
+	arm64: Object.freeze({
+		platform: "windows",
+		architecture: "arm64",
+		installerArchitecture: "arm64",
+		targetTriple: "aarch64-pc-windows-msvc",
+		executableSuffix: ".exe",
+	}),
+});
+
+const ARCHITECTURE_ALIASES = new Map([
+	["x64", "x86_64"],
+	["amd64", "x86_64"],
+	["x86_64", "x86_64"],
+	["arm64", "arm64"],
+	["aarch64", "arm64"],
+]);
+
 function argument(name, fallback) {
 	const index = process.argv.indexOf(name);
-	return index === -1 ? fallback : process.argv[index + 1];
+	if (index === -1) return fallback;
+	const value = process.argv[index + 1];
+	if (!value || value.startsWith("--")) throw new Error(`${name} requires a value`);
+	return value;
+}
+
+function normalizePlatform(value) {
+	const platform = String(value ?? "").trim().toLowerCase();
+	if (platform === "win" || platform === "windows") return "windows";
+	if (platform === "mac" || platform === "macos" || platform === "darwin") return "macos";
+	if (/^[a-z0-9][a-z0-9_.-]*$/i.test(platform)) return platform;
+	throw new Error(`invalid release platform: ${value}`);
+}
+
+function normalizeArchitecture(value, platform) {
+	const normalized = ARCHITECTURE_ALIASES.get(String(value ?? "").trim().toLowerCase());
+	if (platform === "windows") {
+		if (!normalized || !WINDOWS_TARGETS[normalized]) {
+			throw new Error(`unsupported Windows architecture: ${value}; expected x86_64 or arm64`);
+		}
+		return normalized;
+	}
+	if (normalized) return platform === "macos" && normalized === "arm64" ? "aarch64" : normalized;
+	if (String(value ?? "").trim() === "") {
+		return process.arch === "x64" ? "x86_64" : process.arch === "arm64" ? "aarch64" : process.arch;
+	}
+	if (!/^[a-z0-9][a-z0-9_.-]*$/i.test(String(value))) {
+		throw new Error(`invalid release architecture: ${value}`);
+	}
+	return String(value);
 }
 
 function sha256(bytes) {
@@ -92,19 +152,26 @@ function version() {
 	return record.version;
 }
 
-const platform =
-	process.platform === "win32"
-		? "windows"
-		: process.platform === "darwin"
-			? "macos"
-			: process.platform;
-const architecture =
-	process.arch === "x64"
-		? "x86_64"
-		: process.arch === "arm64"
-			? "aarch64"
-			: process.arch;
-const executableSuffix = platform === "windows" ? ".exe" : "";
+const platform = normalizePlatform(
+	argument(
+		"--platform",
+		process.platform === "win32" ? "windows" : process.platform === "darwin" ? "macos" : process.platform,
+	),
+);
+const architecture = normalizeArchitecture(
+	argument(
+		"--architecture",
+		platform === "windows" ? process.env.LEGION_WINDOWS_ARCH ?? "x86_64" : null,
+	),
+	platform,
+);
+const explicitWindowsArchitecture = platform === "windows" &&
+	(process.argv.includes("--architecture") || Boolean(process.env.LEGION_WINDOWS_ARCH));
+if (platform === "windows" && process.platform !== "win32" && !explicitWindowsArchitecture) {
+	throw new Error("cross-building Windows requires explicit --architecture x86_64 or arm64");
+}
+const windowsTarget = platform === "windows" ? WINDOWS_TARGETS[architecture] : null;
+const executableSuffix = windowsTarget?.executableSuffix ?? "";
 const releaseVersion = version();
 const cargoManifest = resolve(
 	repositoryRoot,
@@ -116,9 +183,18 @@ const profile = argument(
 );
 if (!/^[a-z0-9][a-z0-9_-]*$/i.test(profile))
 	throw new Error(`invalid Cargo profile: ${profile}`);
-const cargoTarget = argument("--target", process.env.CARGO_BUILD_TARGET ?? null);
+const requestedCargoTarget = argument("--target", process.env.CARGO_BUILD_TARGET ?? null);
+const cargoTarget = windowsTarget && (explicitWindowsArchitecture || requestedCargoTarget)
+	? windowsTarget.targetTriple
+	: requestedCargoTarget;
+const targetTriple = windowsTarget?.targetTriple ?? cargoTarget;
 if (cargoTarget && !/^[a-z0-9][a-z0-9_.-]*$/i.test(cargoTarget))
 	throw new Error(`invalid Cargo target: ${cargoTarget}`);
+if (windowsTarget && requestedCargoTarget && requestedCargoTarget !== windowsTarget.targetTriple) {
+	throw new Error(
+		`Windows target identity mismatch: architecture ${architecture} requires ${windowsTarget.targetTriple}, received ${requestedCargoTarget}`,
+	);
+}
 const suppliedBinDirectory = argument("--bin-dir", null);
 const binDirectory = suppliedBinDirectory
 	? resolve(suppliedBinDirectory)
@@ -268,6 +344,13 @@ if (
 const provenance =
 	suppliedProvenance ??
 	`${rightReleaseConfig.nativeAssembly.localProvenanceScheme}://${platform}-${architecture}/${runtimeDigest}`;
+const targetIdentity = {
+	platform,
+	architecture,
+	targetTriple,
+	executable: binaryNames[0],
+	installerArchitecture: windowsTarget?.installerArchitecture ?? null,
+};
 const manifest = {
 	releaseVersion,
 	runtime: { platform, architecture, sha256: runtimeDigest, provenance },
@@ -335,6 +418,8 @@ process.stdout.write(
 			platform,
 			architecture,
 			cargoTarget,
+			targetTriple,
+			targetIdentity,
 			finalizedSigned: finalizeSigned,
 			runtimeSha256: runtimeDigest,
 			assetsSha256: manifest.declarativeAssetsSha256,

--- a/scripts/ci/native-installed-smoke.mjs
+++ b/scripts/ci/native-installed-smoke.mjs
@@ -40,13 +40,33 @@ const environment = {
 	LEGION_STATE_ROOT: join(home, "state", "Legion"),
 };
 
-for (const args of [
-	["--version"],
-	["setup", "preview", "--client-evidence", evidencePath, "--client", "codex", "--dry-run"],
-	["setup", "--check"],
-	["setup", "repair", "--client-evidence", evidencePath, "--client", "codex", "--dry-run"],
-]) {
-	const result = spawnSync(binary, args, { env: environment, encoding: "utf8", stdio: "inherit" });
+const invocations = [
+	{ args: ["--version"] },
+	{
+		args: ["--json", "setup", "preview", "--client-evidence", evidencePath, "--client", "codex", "--dry-run"],
+		allowIncomplete: true,
+	},
+	{ args: ["--json", "setup", "--check"], allowIncomplete: true },
+	{
+		args: ["--json", "setup", "repair", "--client-evidence", evidencePath, "--client", "codex", "--dry-run"],
+		allowIncomplete: true,
+	},
+];
+
+for (const { args, allowIncomplete = false } of invocations) {
+	const result = spawnSync(binary, args, { env: environment, encoding: "utf8" });
+	if (result.stdout) process.stdout.write(result.stdout);
+	if (result.stderr) process.stderr.write(result.stderr);
 	if (result.error) throw result.error;
-	if (result.status !== 0) throw new Error(`${binary} ${args.join(" ")} exited ${result.status}`);
+	if (result.status === 0) continue;
+	if (allowIncomplete && [1, 2].includes(result.status)) {
+		let payload;
+		try {
+			payload = JSON.parse(result.stdout);
+		} catch {
+			throw new Error(`${binary} ${args.join(" ")} returned non-JSON incomplete output`);
+		}
+		if (payload.status === "incomplete") continue;
+	}
+	throw new Error(`${binary} ${args.join(" ")} exited ${result.status}`);
 }

--- a/scripts/package-windows-release.mjs
+++ b/scripts/package-windows-release.mjs
@@ -1,0 +1,683 @@
+#!/usr/bin/env node
+
+/**
+ * Build one deterministic Windows portable archive plus its evidence seams.
+ *
+ * This script intentionally produces a BLOCKED manifest when signing,
+ * provenance, or qualification receipts are absent. It never upgrades a
+ * local-build reference into release evidence and never changes the WinGet
+ * channel ledger. `--require-signature` / `--require-evidence` are the
+ * fail-closed gates used by a release invocation.
+ */
+
+import { createHash } from "node:crypto";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	lstatSync,
+	readFileSync,
+	readdirSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { execFileSync } from "node:child_process";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { WINDOWS_ARCHITECTURES } from "../right-release.config.mjs";
+
+const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const REQUIRED_BINARIES = ["legion.exe", "legion-hook.exe", "legion-mcp.exe"];
+const SIGNING_CONTRACT = "windows-raw-exe-authenticode-before-portable-v1";
+const WINDOWS_PLATFORM = "windows";
+const CHANNEL_ID = "winget";
+const CHANNEL_PACKAGE_ID = "OrthicLabs.Legion";
+const EVIDENCE_STATUS = Object.freeze({
+	missing: "missing",
+	invalid: "invalid",
+	verified: "verified",
+});
+
+const ARCHITECTURE_ALIASES = new Map([
+	["x64", "x86_64"],
+	["amd64", "x86_64"],
+	["x86_64", "x86_64"],
+	["windows-x86_64", "x86_64"],
+	["arm64", "arm64"],
+	["aarch64", "arm64"],
+	["windows-arm64", "arm64"],
+]);
+
+export function normalizeWindowsArchitecture(value) {
+	const key = String(value ?? "").trim().toLowerCase();
+	const architecture = ARCHITECTURE_ALIASES.get(key);
+	if (!architecture || !WINDOWS_ARCHITECTURES[architecture]) {
+		throw new Error(`unsupported Windows architecture: ${value}; expected x86_64 or arm64`);
+	}
+	return architecture;
+}
+
+export function windowsTargetIdentity(value) {
+	const architecture = normalizeWindowsArchitecture(value);
+	const configured = WINDOWS_ARCHITECTURES[architecture];
+	return {
+		platform: WINDOWS_PLATFORM,
+		architecture,
+		targetTriple: configured.targetTriple,
+		wingetArchitecture: configured.wingetArchitecture,
+		executable: "legion.exe",
+		artifactId: configured.artifactId,
+	};
+}
+
+function sha256(bytes) {
+	return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function fileDigest(path) {
+	return sha256(readFileSync(path));
+}
+
+function bareDigest(value) {
+	return String(value ?? "").replace(/^sha256:/i, "").toLowerCase();
+}
+
+function readJson(path, label) {
+	if (!existsSync(path)) throw new Error(`${label} is missing: ${path}`);
+	try {
+		return JSON.parse(readFileSync(path, "utf8"));
+	} catch (error) {
+		throw new Error(`${label} is not valid JSON: ${path} (${error.message})`);
+	}
+}
+
+function resolveInside(root, candidate, label = "path") {
+	const resolvedRoot = resolve(root);
+	const resolved = resolve(resolvedRoot, candidate);
+	const rel = relative(resolvedRoot, resolved);
+	if (!rel || rel === ".." || rel.startsWith(`..${sep}`) || rel.includes("\0")) {
+		throw new Error(`${label} escapes its root: ${candidate}`);
+	}
+	return resolved;
+}
+
+function relativePortablePath(root, file) {
+	const rel = relative(resolve(root), resolve(file)).split(sep).join("/");
+	if (!rel || rel === ".." || rel.startsWith("../") || rel.includes("\0")) {
+		throw new Error(`portable path escapes release root: ${file}`);
+	}
+	if (rel.split("/").some((part) => part === ".git" || part === "node_modules")) {
+		throw new Error(`development-only path cannot ship in portable archive: ${rel}`);
+	}
+	return rel;
+}
+
+function filesBelow(root, directory = root, output = []) {
+	for (const entry of readdirSync(directory, { withFileTypes: true })) {
+		const path = join(directory, entry.name);
+		const metadata = lstatSync(path);
+		if (metadata.isSymbolicLink()) throw new Error(`portable release asset is symlink: ${path}`);
+		if (metadata.isDirectory()) filesBelow(root, path, output);
+		else if (metadata.isFile()) output.push(relativePortablePath(root, path));
+		else throw new Error(`portable release asset is not a regular file: ${path}`);
+	}
+	return output.sort();
+}
+
+function crc32(bytes) {
+	let crc = 0xffffffff;
+	for (const byte of bytes) {
+		crc ^= byte;
+		for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+	}
+	return (crc ^ 0xffffffff) >>> 0;
+}
+
+function zipEntry(name, bytes, offset) {
+	const filename = Buffer.from(name, "utf8");
+	if (!filename.length || filename.length > 0xffff) throw new Error(`invalid ZIP entry name: ${name}`);
+	if (bytes.length > 0xffffffff || offset > 0xffffffff) throw new Error(`ZIP32 limit exceeded by ${name}`);
+	const checksum = crc32(bytes);
+	const local = Buffer.alloc(30 + filename.length);
+	local.writeUInt32LE(0x04034b50, 0);
+	local.writeUInt16LE(20, 4);
+	local.writeUInt16LE(0x800, 6);
+	local.writeUInt16LE(0, 8);
+	local.writeUInt16LE(0, 10);
+	local.writeUInt16LE(0, 12);
+	local.writeUInt32LE(checksum, 14);
+	local.writeUInt32LE(bytes.length, 18);
+	local.writeUInt32LE(bytes.length, 22);
+	local.writeUInt16LE(filename.length, 26);
+	local.writeUInt16LE(0, 28);
+	filename.copy(local, 30);
+
+	const central = Buffer.alloc(46 + filename.length);
+	central.writeUInt32LE(0x02014b50, 0);
+	central.writeUInt16LE(20, 4);
+	central.writeUInt16LE(20, 6);
+	central.writeUInt16LE(0x800, 8);
+	central.writeUInt16LE(0, 10);
+	central.writeUInt16LE(0, 12);
+	central.writeUInt16LE(0, 14);
+	central.writeUInt32LE(checksum, 16);
+	central.writeUInt32LE(bytes.length, 20);
+	central.writeUInt32LE(bytes.length, 24);
+	central.writeUInt16LE(filename.length, 28);
+	central.writeUInt16LE(0, 30);
+	central.writeUInt16LE(0, 32);
+	central.writeUInt16LE(0, 34);
+	central.writeUInt16LE(0, 36);
+	central.writeUInt32LE(0, 38);
+	central.writeUInt32LE(offset, 42);
+	filename.copy(central, 46);
+	return { local, central };
+}
+
+/**
+ * Write a deterministic, store-only ZIP. Node has no built-in archive writer;
+ * keeping this writer dependency-free avoids a package/install step in the
+ * Windows release lane. Entries are sorted and carry a fixed DOS timestamp.
+ */
+export function createPortableZip(root, files = filesBelow(root)) {
+	const sortedFiles = [...files].sort();
+	if (new Set(sortedFiles).size !== sortedFiles.length) throw new Error("portable ZIP entries must be unique");
+	const locals = [];
+	const centrals = [];
+	let offset = 0;
+	for (const name of sortedFiles) {
+		if (name.includes("\\") || name.split("/").some((part) => part === ".." || part === "")) {
+			throw new Error(`unsafe portable ZIP entry: ${name}`);
+		}
+		const bytes = readFileSync(resolveInside(root, name, "portable ZIP entry"));
+		const entry = zipEntry(name, bytes, offset);
+		locals.push(entry.local, bytes);
+		centrals.push(entry.central);
+		offset += entry.local.length + bytes.length;
+	}
+	const centralDirectory = Buffer.concat(centrals);
+	if (sortedFiles.length > 0xffff || centralDirectory.length > 0xffffffff || offset > 0xffffffff) {
+		throw new Error("portable ZIP exceeds ZIP32 limits");
+	}
+	const end = Buffer.alloc(22);
+	end.writeUInt32LE(0x06054b50, 0);
+	end.writeUInt16LE(0, 4);
+	end.writeUInt16LE(0, 6);
+	end.writeUInt16LE(sortedFiles.length, 8);
+	end.writeUInt16LE(sortedFiles.length, 10);
+	end.writeUInt32LE(centralDirectory.length, 12);
+	end.writeUInt32LE(offset, 16);
+	end.writeUInt16LE(0, 20);
+	return Buffer.concat([...locals, centralDirectory, end]);
+}
+
+function atomicWrite(path, bytes, { force = false } = {}) {
+	if (existsSync(path) && !force) throw new Error(`release output exists: ${path}; pass --force to replace exact output`);
+	mkdirSync(dirname(path), { recursive: true });
+	const temporary = `${path}.${process.pid}.tmp`;
+	try {
+		writeFileSync(temporary, bytes);
+		renameSync(temporary, path);
+	} finally {
+		if (existsSync(temporary)) rmSync(temporary, { force: true });
+	}
+}
+
+function assertVersion(value) {
+	if (typeof value !== "string" || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(value)) {
+		throw new Error(`invalid release version: ${value}`);
+	}
+	if (/-dev\./i.test(value)) throw new Error(`development release version cannot be packaged: ${value}`);
+	return value;
+}
+
+function assertSourceRevision(value) {
+	if (!/^[0-9a-f]{7,64}$/i.test(String(value ?? ""))) {
+		throw new Error(`source revision must be a hexadecimal Git revision: ${value ?? "<missing>"}`);
+	}
+	return String(value).toLowerCase();
+}
+
+function sourceRevision(provided, root) {
+	const value = provided ?? process.env.GITHUB_SHA ?? process.env.SOURCE_REVISION;
+	if (value) return assertSourceRevision(value);
+	try {
+		return assertSourceRevision(execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim());
+	} catch (error) {
+		throw new Error(`source revision is required; pass --source-revision (${error.message})`);
+	}
+}
+
+function releaseMetadata(inputRoot, expected) {
+	const path = resolveInside(inputRoot, "share/legion/release.json", "release identity");
+	const metadata = readJson(path, "release identity");
+	if (metadata.releaseVersion == null) throw new Error(`release identity has no releaseVersion: ${path}`);
+	const releaseVersion = assertVersion(metadata.releaseVersion);
+	if (expected && releaseVersion !== expected) throw new Error(`release version mismatch: expected ${expected}, got ${releaseVersion}`);
+	const runtime = metadata.runtime;
+	if (!runtime || typeof runtime !== "object") throw new Error(`release identity has no runtime: ${path}`);
+	const identity = windowsTargetIdentity(runtime.architecture);
+	const observedPlatform = String(runtime.platform ?? "").toLowerCase();
+	if (observedPlatform !== "windows" && observedPlatform !== "win32" && observedPlatform !== "win") {
+		throw new Error(`release identity platform is not Windows: ${runtime.platform}`);
+	}
+	if (!runtime.sha256) {
+		throw new Error(`release identity has no final runtime digest: ${path}`);
+	}
+	if (
+		!["windows", "win32", "win"].includes(String(runtime.platform ?? "").toLowerCase())
+		|| runtime.architecture !== identity.architecture
+	) {
+		throw new Error(`release runtime platform or architecture does not match target identity: ${path}`);
+	}
+	return { metadata, releaseVersion, identity, path };
+}
+
+function assertBinaries(inputRoot, identity) {
+	for (const name of REQUIRED_BINARIES) {
+		const path = resolveInside(inputRoot, `bin/${name}`, "release binary");
+		if (!existsSync(path)) throw new Error(`release binary missing: ${path}`);
+	}
+	const runtimePath = resolveInside(inputRoot, `bin/${identity.executable}`, "runtime binary");
+	const runtimeDigest = fileDigest(runtimePath);
+	const declaredDigest = identity.runtimeDigest;
+	if (declaredDigest && bareDigest(declaredDigest) !== bareDigest(runtimeDigest)) {
+		throw new Error(`release identity runtime digest mismatch: ${declaredDigest} != ${runtimeDigest}`);
+	}
+	return { runtimePath, runtimeDigest };
+}
+
+function signatureEvidence({ receiptPath, inputRoot, identity }) {
+	const base = {
+		schemaVersion: 1,
+		kind: "legion-windows-signature-evidence",
+		contract: SIGNING_CONTRACT,
+		targetIdentity: identity,
+		artifacts: REQUIRED_BINARIES.map((name) => ({ path: `bin/${name}`, sha256: fileDigest(resolveInside(inputRoot, `bin/${name}`, "signed binary")) })),
+	};
+	if (!receiptPath || !existsSync(receiptPath)) {
+		return {
+			...base,
+			status: EVIDENCE_STATUS.missing,
+			reason: "A RightKit Windows signing receipt is required; no local receipt is a signature.",
+		};
+	}
+	let receipt;
+	try {
+		receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
+	} catch (error) {
+		return { ...base, status: EVIDENCE_STATUS.invalid, reason: `invalid signing receipt JSON: ${error.message}` };
+	}
+	if (receipt.schema !== 1 || !Array.isArray(receipt.files) || receipt.files.length !== REQUIRED_BINARIES.length) {
+		return { ...base, status: EVIDENCE_STATUS.invalid, reason: "signing receipt schema/files are invalid" };
+	}
+	const receiptDirectory = dirname(resolve(receiptPath));
+	const signed = [];
+	for (const name of REQUIRED_BINARIES) {
+		const expectedPath = resolveInside(inputRoot, `bin/${name}`, "signed binary");
+		const expectedDigest = fileDigest(expectedPath);
+		const matches = receipt.files.filter((item) => {
+			const candidates = item?.file
+				? [resolve(item.file), resolve(receiptDirectory, item.file)]
+				: [];
+			return candidates.includes(resolve(expectedPath)) && bareDigest(item?.after?.sha256) === bareDigest(expectedDigest);
+		});
+		if (matches.length !== 1) {
+			return { ...base, status: EVIDENCE_STATUS.invalid, reason: `receipt does not bind exactly one final digest for ${name}` };
+		}
+		const item = matches[0];
+		if (
+			item.authenticode !== "Valid"
+			|| item.subject !== "CN=Damned Ventures LLC"
+			|| item.timestampPresent !== true
+			|| item.after?.sizeBytes !== lstatSync(expectedPath).size
+		) {
+			return { ...base, status: EVIDENCE_STATUS.invalid, reason: `receipt lacks Valid Authenticode, expected subject, or trusted timestamp for ${name}` };
+		}
+		signed.push({ path: `bin/${name}`, file: item.file, sha256: item.after.sha256, sizeBytes: item.after.sizeBytes });
+	}
+	return {
+		...base,
+		status: EVIDENCE_STATUS.verified,
+		receipt: { schema: receipt.schema, files: signed },
+	};
+}
+
+function provenanceEvidence({ evidencePath, archiveDigest, runtimeDigest, identity, releaseVersion, sourceRevision }) {
+	const base = {
+		schemaVersion: 1,
+		kind: "legion-windows-provenance-evidence",
+		targetIdentity: identity,
+		releaseVersion,
+		sourceRevision,
+		archiveSha256: archiveDigest,
+		runtimeSha256: runtimeDigest,
+		requiredScheme: "rightkit-release://",
+	};
+	if (!evidencePath || !existsSync(evidencePath)) {
+		return { ...base, status: EVIDENCE_STATUS.missing, reason: "RightKit provenance evidence is required for publication." };
+	}
+	const value = readJson(evidencePath, "provenance evidence");
+	const locator = value.provenance ?? value.locator ?? value.uri;
+	const observedArchive = value.archiveSha256 ?? value.artifact?.sha256;
+	const valid = (value.status === "verified" || value.status === "complete" || value.status === "pass")
+		&& typeof locator === "string"
+		&& locator.startsWith("rightkit-release://")
+		&& typeof observedArchive === "string"
+		&& bareDigest(observedArchive) === bareDigest(archiveDigest);
+	return valid
+		? { ...base, status: EVIDENCE_STATUS.verified, source: value }
+		: { ...base, status: EVIDENCE_STATUS.invalid, reason: "provenance must be verified, rightkit-release:// bound, and archive-digest bound", source: value };
+}
+
+function qualificationEvidence({ evidencePath, archiveDigest, runtimeDigest, identity, releaseVersion, sourceRevision }) {
+	const base = {
+		schemaVersion: 1,
+		kind: "legion-windows-qualification-evidence",
+		targetIdentity: identity,
+		releaseVersion,
+		sourceRevision,
+		archiveSha256: archiveDigest,
+		runtimeSha256: runtimeDigest,
+		requiredGates: ["installed-product", "command-resolution", "client-integration", "update", "rollback", "uninstall"],
+	};
+	if (!evidencePath || !existsSync(evidencePath)) {
+		return { ...base, status: EVIDENCE_STATUS.missing, reason: "installed-product qualification evidence is required for publication." };
+	}
+	const value = readJson(evidencePath, "qualification evidence");
+	const observedArchive = value.archiveSha256 ?? value.artifact?.sha256;
+	const observedRuntime = value.runtimeSha256 ?? value.runtime?.sha256;
+	const valid = ["qualified", "verified", "complete", "pass"].includes(String(value.status ?? "").toLowerCase())
+		&& typeof observedArchive === "string"
+		&& typeof observedRuntime === "string"
+		&& bareDigest(observedArchive) === bareDigest(archiveDigest)
+		&& bareDigest(observedRuntime) === bareDigest(runtimeDigest);
+	return valid
+		? { ...base, status: EVIDENCE_STATUS.verified, source: value }
+		: { ...base, status: EVIDENCE_STATUS.invalid, reason: "qualification must be a passing, archive-digest-bound installed-product receipt", source: value };
+}
+
+function buildSbom({ identity, releaseVersion, sourceRevision, files, inputRoot }) {
+	const components = files
+		.filter((name) => name.toLowerCase().endsWith(".exe"))
+		.map((name) => ({
+			type: "application",
+			name: basename(name, ".exe"),
+			version: releaseVersion,
+			bomRef: `legion:${identity.architecture}:${name}`,
+			hashes: [{ alg: "SHA-256", content: bareDigest(fileDigest(resolveInside(inputRoot, name))) }],
+			properties: [
+				{ name: "legion.platform", value: identity.platform },
+				{ name: "legion.architecture", value: identity.architecture },
+				{ name: "legion.targetTriple", value: identity.targetTriple },
+			],
+		}));
+	return {
+		bomFormat: "CycloneDX",
+		specVersion: "1.5",
+		serialNumber: `urn:legion:windows:${identity.architecture}:${sourceRevision}`,
+		version: 1,
+		metadata: {
+			component: { type: "application", name: "@orthic-labs/legion", version: releaseVersion },
+			properties: [
+				{ name: "legion.platform", value: identity.platform },
+				{ name: "legion.architecture", value: identity.architecture },
+				{ name: "legion.targetTriple", value: identity.targetTriple },
+			],
+		},
+		components,
+	};
+}
+
+function writeChecksums(outputDir, names, { force }) {
+	const lines = names
+		.sort()
+		.map((name) => `${bareDigest(fileDigest(join(outputDir, name)))}  ${name}`);
+	const path = join(outputDir, "SHA256SUMS");
+	atomicWrite(path, Buffer.from(`${lines.join("\n")}\n`, "utf8"), { force });
+	return { path, digest: fileDigest(path) };
+}
+
+function statusReady(evidence) {
+	return evidence.signature.status === EVIDENCE_STATUS.verified
+		&& evidence.provenance.status === EVIDENCE_STATUS.verified
+		&& evidence.qualification.status === EVIDENCE_STATUS.verified;
+}
+
+export function buildWindowsReleasePackage({
+	input,
+	output,
+	architecture,
+	sourceRevision: suppliedSourceRevision,
+	signatureReceipt,
+	provenance,
+	qualification,
+	notices,
+	force = false,
+	requireSignature = false,
+	requireEvidence = false,
+	repositoryRoot = REPOSITORY_ROOT,
+} = {}) {
+	if (!input) throw new Error("--input is required; package an assembled release root, never a source checkout");
+	const inputRoot = resolve(input);
+	if (!existsSync(inputRoot) || !lstatSync(inputRoot).isDirectory()) throw new Error(`assembled release root is missing: ${inputRoot}`);
+	const identity = windowsTargetIdentity(architecture);
+	const expectedVersionRecord = readJson(join(repositoryRoot, "release", "version.json"), "release version record");
+	const expectedVersion = assertVersion(expectedVersionRecord.version);
+	const release = releaseMetadata(inputRoot, expectedVersion);
+	if (release.identity.architecture !== identity.architecture || release.identity.targetTriple !== identity.targetTriple) {
+		throw new Error(`assembled release target does not match requested ${identity.architecture}`);
+	}
+	const binaries = assertBinaries(inputRoot, { ...identity, runtimeDigest: release.metadata.runtime.sha256 });
+	const files = filesBelow(inputRoot);
+	const revision = sourceRevision(suppliedSourceRevision, repositoryRoot);
+	const outputDir = resolve(output ?? join(repositoryRoot, "dist", "releases", "windows", release.releaseVersion, identity.architecture));
+	if (outputDir === resolve(repositoryRoot) || outputDir === inputRoot) {
+		throw new Error(`unsafe release output path: ${outputDir}`);
+	}
+	if (existsSync(outputDir) && !force && readdirSync(outputDir).length > 0) {
+		throw new Error(`release output directory is not empty: ${outputDir}; pass --force to replace exact output`);
+	}
+	if (existsSync(outputDir) && force) rmSync(outputDir, { recursive: true, force: true });
+	mkdirSync(outputDir, { recursive: true });
+	const archiveName = `legion-${release.releaseVersion}-windows-${identity.architecture}.zip`;
+	const archivePath = join(outputDir, archiveName);
+	const archiveBytes = createPortableZip(inputRoot, files);
+	atomicWrite(archivePath, archiveBytes, { force });
+	const archiveDigest = fileDigest(archivePath);
+
+	const sbomName = "SBOM.cdx.json";
+	const noticesName = "THIRD_PARTY_NOTICES.md";
+	const provenanceName = "provenance.json";
+	const qualificationName = "qualification.json";
+	const signatureName = "signature.json";
+	const notarizationName = "notarization.json";
+	const wingetName = "winget-portable.json";
+	const manifestName = "release-manifest.json";
+	const noticeSource = resolve(repositoryRoot, notices ?? join(repositoryRoot, "docs", "THIRD_PARTY_NOTICES.md"));
+	if (!existsSync(noticeSource)) throw new Error(`third-party notice source is missing: ${noticeSource}`);
+	const noticeMetadata = lstatSync(noticeSource);
+	if (!noticeMetadata.isFile() || noticeMetadata.isSymbolicLink()) {
+		throw new Error(`third-party notice source is not a regular file: ${noticeSource}`);
+	}
+	const noticePath = join(outputDir, noticesName);
+	if (existsSync(noticePath) && !force) throw new Error(`release output exists: ${noticePath}; pass --force to replace exact output`);
+	copyFileSync(noticeSource, noticePath);
+
+	const sbomPath = join(outputDir, sbomName);
+	atomicWrite(sbomPath, Buffer.from(`${JSON.stringify(buildSbom({ identity, releaseVersion: release.releaseVersion, sourceRevision: revision, files, inputRoot }), null, 2)}\n`), { force });
+	const signatures = signatureEvidence({
+		receiptPath: signatureReceipt
+			? resolve(repositoryRoot, signatureReceipt)
+			: process.env.LEGION_WINDOWS_SIGNATURE_RECEIPT
+				? resolve(repositoryRoot, process.env.LEGION_WINDOWS_SIGNATURE_RECEIPT)
+				: join(repositoryRoot, ".right-release", "receipts", `windows-${identity.architecture}-raw-exe.json`),
+		inputRoot,
+		identity,
+	});
+	const notarization = {
+		schemaVersion: 1,
+		kind: "legion-windows-notarization-evidence",
+		status: "not-applicable",
+		reason: "Windows portable artifacts use Authenticode and trusted timestamp; Apple notarization does not apply.",
+		targetIdentity: identity,
+	};
+	const provenanceRecord = provenanceEvidence({
+		evidencePath: provenance ? resolve(repositoryRoot, provenance) : null,
+		archiveDigest,
+		runtimeDigest: binaries.runtimeDigest,
+		identity,
+		releaseVersion: release.releaseVersion,
+		sourceRevision: revision,
+	});
+	const qualificationRecord = qualificationEvidence({
+		evidencePath: qualification ? resolve(repositoryRoot, qualification) : null,
+		archiveDigest,
+		runtimeDigest: binaries.runtimeDigest,
+		identity,
+		releaseVersion: release.releaseVersion,
+		sourceRevision: revision,
+	});
+	for (const [name, value] of [
+		[signatureName, signatures],
+		[notarizationName, notarization],
+		[provenanceName, provenanceRecord],
+		[qualificationName, qualificationRecord],
+	]) atomicWrite(join(outputDir, name), Buffer.from(`${JSON.stringify(value, null, 2)}\n`), { force });
+
+	const wingetRecord = {
+		schemaVersion: 1,
+		kind: "legion-winget-portable-artifact",
+		status: "BLOCKED",
+		packageIdentifier: CHANNEL_PACKAGE_ID,
+		installerType: "portable",
+		architecture: identity.wingetArchitecture,
+		platform: identity.platform,
+		version: release.releaseVersion,
+		targetTriple: identity.targetTriple,
+		installer: { path: archiveName, sha256: archiveDigest, url: null },
+		requiredEvidence: ["authenticode", "trusted-timestamp", "provenance", "installed-product-qualification", "channel-authorization"],
+		reason: "WinGet publication remains blocked until immutable signed installed-product evidence and channel authorization exist.",
+	};
+	const wingetPath = join(outputDir, wingetName);
+	atomicWrite(wingetPath, Buffer.from(`${JSON.stringify(wingetRecord, null, 2)}\n`), { force });
+
+	const evidence = { signature: signatures, provenance: provenanceRecord, qualification: qualificationRecord };
+	const evidenceReady = statusReady(evidence);
+	const checksumFiles = [archiveName, sbomName, noticesName, provenanceName, qualificationName, signatureName, notarizationName, wingetName];
+	const checksums = writeChecksums(outputDir, checksumFiles, { force });
+	const recordFor = (name, extras = {}) => ({ path: name, digest: fileDigest(join(outputDir, name)), ...extras });
+	const manifest = {
+		schemaVersion: 1,
+		kind: "legion-release-manifest",
+		releaseType: "windows-portable",
+		releaseStatus: evidenceReady ? "QUALIFIED_BUT_UNPUBLISHED" : "BLOCKED",
+		version: release.releaseVersion,
+		sourceRevision: revision,
+		targetIdentity: identity,
+		portable: {
+			packageManager: "WinGet",
+			packageIdentifier: CHANNEL_PACKAGE_ID,
+			installerType: "portable",
+			archive: recordFor(archiveName, { type: "portable-archive", platform: identity.platform, architecture: identity.architecture, targetTriple: identity.targetTriple, semanticEquivalent: true }),
+		},
+		artifacts: [recordFor(archiveName, { type: "portable-archive", platform: identity.platform, architecture: identity.architecture, targetTriple: identity.targetTriple, semanticEquivalent: true })],
+		checksums: [checksums],
+		sboms: [recordFor(sbomName, { format: "CycloneDX" })],
+		notices: [recordFor(noticesName)],
+		provenance: [recordFor(provenanceName, { status: provenanceRecord.status })],
+		attestations: [recordFor(provenanceName, { status: provenanceRecord.status })],
+		signatures: [recordFor(signatureName, { status: signatures.status, contract: SIGNING_CONTRACT })],
+		notarization: [recordFor(notarizationName, { status: notarization.status })],
+		qualificationArtifacts: [recordFor(qualificationName, { status: qualificationRecord.status })],
+		packageManagerMetadata: [recordFor(wingetName, { status: wingetRecord.status, channel: CHANNEL_ID })],
+		channels: [{
+			id: CHANNEL_ID,
+			decision: "BLOCKED",
+			reason: wingetRecord.reason,
+			artifacts: [{ path: archiveName, decision: "BLOCKED" }],
+		}],
+		requiredEvidence: wingetRecord.requiredEvidence,
+	};
+	const manifestPath = join(outputDir, manifestName);
+	atomicWrite(manifestPath, Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`), { force });
+
+	if (requireSignature && signatures.status !== EVIDENCE_STATUS.verified) {
+		throw new Error(`Windows release signing is not verified: ${signatures.reason}`);
+	}
+	if (requireEvidence && !evidenceReady) {
+		throw new Error(`Windows release evidence is incomplete: signature=${signatures.status}, provenance=${provenanceRecord.status}, qualification=${qualificationRecord.status}`);
+	}
+	return {
+		status: manifest.releaseStatus,
+		channel: "BLOCKED",
+		outputDir,
+		archive: archivePath,
+		manifest: manifestPath,
+		architecture: identity.architecture,
+		targetTriple: identity.targetTriple,
+		archiveSha256: archiveDigest,
+		runtimeSha256: binaries.runtimeDigest,
+		evidence: {
+			signature: signatures.status,
+			provenance: provenanceRecord.status,
+			qualification: qualificationRecord.status,
+		},
+	};
+}
+
+function parseArguments(argv) {
+	const options = {};
+	for (let index = 0; index < argv.length; index += 1) {
+		const raw = argv[index];
+		if (raw === "--") continue;
+		if (raw === "--force" || raw === "--require-signature" || raw === "--require-evidence" || raw === "--json") {
+			options[raw.slice(2).replaceAll("-", "")] = true;
+			continue;
+		}
+		const equal = raw.indexOf("=");
+		const key = equal === -1 ? raw.slice(2) : raw.slice(2, equal);
+		if (!raw.startsWith("--") || !key) throw new Error(`unknown argument: ${raw}`);
+		const value = equal === -1 ? argv[++index] : raw.slice(equal + 1);
+		if (!value || value.startsWith("--")) throw new Error(`${raw} requires a value`);
+		options[key.replaceAll("-", "")] = value;
+	}
+	return options;
+}
+
+function usage(code = 0) {
+	console.error("usage: node scripts/package-windows-release.mjs --architecture x86_64|arm64 --input <assembled-root> [--output <dir>] [--source-revision <sha>] [--signature-receipt <json>] [--provenance <json>] [--qualification <json>] [--force] [--require-signature] [--require-evidence] [--json]");
+	process.exit(code);
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+if (isMain) {
+	try {
+		if (process.argv.includes("--help") || process.argv.includes("-h")) usage(0);
+		const options = parseArguments(process.argv.slice(2));
+		const architecture = options.architecture ?? process.env.LEGION_WINDOWS_ARCH;
+		if (!architecture) throw new Error("--architecture is required; choose x86_64 or arm64");
+		const normalized = normalizeWindowsArchitecture(architecture);
+		const configured = WINDOWS_ARCHITECTURES[normalized];
+		const input = options.input ?? join(REPOSITORY_ROOT, configured.assemblyRoot);
+		const result = buildWindowsReleasePackage({
+			input,
+			output: options.output ?? options.out,
+			architecture: normalized,
+			sourceRevision: options.sourcerevision,
+			signatureReceipt: options.signaturereceipt,
+			provenance: options.provenance,
+			qualification: options.qualification,
+			notices: options.notices,
+			force: options.force === true,
+			requireSignature: options.requiresignature === true,
+			requireEvidence: options.requireevidence === true,
+		});
+		if (options.json) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+		else process.stdout.write(`windows package ${result.status}: ${result.archive} (${result.architecture}/${result.targetTriple})\n`);
+	} catch (error) {
+		console.error(`package-windows-release: ${error.message}`);
+		process.exit(1);
+	}
+}

--- a/tests/ci-contract.test.mjs
+++ b/tests/ci-contract.test.mjs
@@ -25,6 +25,8 @@ test('CI pins toolchains, gates all supported hosts, and smoke-tests installed p
   assert.match(smoke, /"setup", "preview"/);
   assert.match(smoke, /"setup", "--check"/);
   assert.match(smoke, /"setup", "repair"/);
+  assert.match(smoke, /allowIncomplete/);
+  assert.match(smoke, /payload\.status === "incomplete"/);
   const actionRefs = [...ci.matchAll(/^\s*-?\s*uses:\s*[^@\s]+@([^\s#]+)/gm)].map((match) => match[1]);
   assert.ok(actionRefs.length >= 5);
   for (const ref of actionRefs) assert.match(ref, /^[0-9a-f]{40}$/);

--- a/tests/release-artifacts.test.mjs
+++ b/tests/release-artifacts.test.mjs
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 import { sha256File, verifyReleaseManifest } from '../scripts/verify-release.mjs';
+import { buildWindowsReleasePackage, normalizeWindowsArchitecture } from '../scripts/package-windows-release.mjs';
 
 function readFile(path) {
   return readFileSync(fileURLToPath(path), 'utf8');
@@ -73,11 +74,98 @@ test('verifyReleaseManifest rejects missing required artifacts', () => {
   }
 });
 
-test('right-release config fails closed until local signed targets exist', () => {
+test('right-release config keeps signing and publication fail-closed', () => {
   const config = readReleaseConfig();
-  assert.match(config, /signed: false/);
+  assert.match(config, /hostedWorkflows: "right-git-ci-only"/);
+  assert.match(config, /signed: true/);
   assert.match(config, /publishBlocked/);
   assert.match(config, /signedProvenanceScheme: "rightkit-release"/);
+  assert.match(config, /x86_64-pc-windows-msvc/);
+  assert.match(config, /aarch64-pc-windows-msvc/);
+  assert.match(config, /packageKind: "portable-zip"/);
+  assert.match(config, /legion-hook\.exe/);
+  assert.match(config, /legion-mcp\.exe/);
+  assert.doesNotMatch(config, /files:\s*\[/);
+});
+
+test('Windows package binds target identity and emits blocked evidence seams', () => {
+  const repositoryRoot = mkdtempSync(join(tmpdir(), 'legion-win-package-'));
+  const input = join(repositoryRoot, 'assembled');
+  const output = join(repositoryRoot, 'out');
+  try {
+    mkdirSync(join(repositoryRoot, 'release'), { recursive: true });
+    mkdirSync(join(repositoryRoot, 'docs'), { recursive: true });
+    mkdirSync(join(input, 'bin'), { recursive: true });
+    mkdirSync(join(input, 'share', 'legion'), { recursive: true });
+    writeFileSync(join(repositoryRoot, 'release', 'version.json'), JSON.stringify({ schemaVersion: 1, kind: 'legion-release-version', version: '0.1.0' }));
+    writeFileSync(join(repositoryRoot, 'docs', 'THIRD_PARTY_NOTICES.md'), 'Legion notice\n');
+    for (const name of ['legion.exe', 'legion-hook.exe', 'legion-mcp.exe']) writeFileSync(join(input, 'bin', name), `${name}\n`);
+    const runtimeDigest = sha256File(join(input, 'bin', 'legion.exe')).slice('sha256:'.length);
+    writeFileSync(join(input, 'share', 'legion', 'release.json'), JSON.stringify({
+      releaseVersion: '0.1.0',
+      runtime: { platform: 'windows', architecture: 'x86_64', sha256: runtimeDigest, provenance: 'local-build://windows-x86_64' },
+    }));
+    const result = buildWindowsReleasePackage({ input, output, architecture: 'x86_64', repositoryRoot, sourceRevision: 'a'.repeat(40), force: true });
+    assert.equal(result.status, 'BLOCKED');
+    assert.equal(result.channel, 'BLOCKED');
+    assert.equal(result.targetTriple, 'x86_64-pc-windows-msvc');
+    assert.equal(normalizeWindowsArchitecture('windows-x86_64'), 'x86_64');
+    assert.ok(existsSync(result.archive));
+    const manifest = JSON.parse(readFileSync(result.manifest, 'utf8'));
+    assert.equal(manifest.targetIdentity.architecture, 'x86_64');
+    assert.equal(manifest.targetIdentity.targetTriple, 'x86_64-pc-windows-msvc');
+    assert.equal(manifest.channels[0].decision, 'BLOCKED');
+    assert.equal(manifest.signatures[0].status, 'missing');
+    assert.equal(manifest.qualificationArtifacts[0].status, 'missing');
+    assert.equal(manifest.provenance[0].status, 'missing');
+    assert.ok(existsSync(join(output, 'SHA256SUMS')));
+    assert.ok(existsSync(join(output, 'SBOM.cdx.json')));
+    assert.ok(existsSync(join(output, 'winget-portable.json')));
+
+    const receiptPath = join(repositoryRoot, '.right-release', 'receipts', 'windows-x86_64-raw-exe.json');
+    mkdirSync(join(repositoryRoot, '.right-release', 'receipts'), { recursive: true });
+    const signedFiles = ['legion.exe', 'legion-hook.exe', 'legion-mcp.exe'].map((name) => {
+      const file = join(input, 'bin', name);
+      return {
+        file,
+        after: { sha256: sha256File(file).slice('sha256:'.length), sizeBytes: readFileSync(file).length },
+        authenticode: 'Valid',
+        subject: 'CN=Damned Ventures LLC',
+        timestampPresent: true,
+      };
+    });
+    writeFileSync(receiptPath, JSON.stringify({ schema: 1, files: signedFiles }));
+    const signedResult = buildWindowsReleasePackage({
+      input,
+      output: join(repositoryRoot, 'signed-out'),
+      architecture: 'x86_64',
+      repositoryRoot,
+      sourceRevision: 'a'.repeat(40),
+      signatureReceipt: receiptPath,
+      requireSignature: true,
+      force: true,
+    });
+    assert.equal(signedResult.evidence.signature, 'verified');
+    const signedManifest = JSON.parse(readFileSync(signedResult.manifest, 'utf8'));
+    assert.equal(signedManifest.signatures[0].status, 'verified');
+    assert.equal(JSON.parse(readFileSync(join(signedResult.outputDir, 'signature.json'), 'utf8')).artifacts.length, 3);
+    writeFileSync(receiptPath, JSON.stringify({ schema: 1, files: signedFiles.slice(0, 2) }));
+    assert.throws(
+      () => buildWindowsReleasePackage({
+        input,
+        output: join(repositoryRoot, 'invalid-out'),
+        architecture: 'x86_64',
+        repositoryRoot,
+        sourceRevision: 'a'.repeat(40),
+        signatureReceipt: receiptPath,
+        requireSignature: true,
+        force: true,
+      }),
+      /Windows release signing is not verified/,
+    );
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
 });
 
 test('public Actions surface contains only right-git managed CI', () => {


### PR DESCRIPTION
Completes Windows x64 native setup, safe plain-name Codex skill reconciliation, Claude hook hard gates, stable repair grammar, current pnpm/Cargo closure, RightKit-managed release assembly, and truthfully blocked WinGet packaging evidence.\n\nVerified locally:\n- pnpm test: 1334/1334\n- pnpm legion:check\n- cargo test --workspace through RightKit\n- Windows x64 release build, assembly, install, setup repair, and package generation