### PR TITLE
Recognize current Claude plugin cache copies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 .audit/
 .audit
 .legion/
+.right-release/
 .agent/
 __pycache__/
 *.pyc

--- a/engine/crates/legion-host/src/codex_skills.rs
+++ b/engine/crates/legion-host/src/codex_skills.rs
@@ -1164,8 +1164,11 @@ fn read_package_tree(
             return Err(format!("package contains symlink {relative}"));
         }
         if metadata.is_dir() {
-            directories.push(relative);
+            let file_count = files.len();
             read_package_tree(root, &path, directories, files)?;
+            if files.len() > file_count {
+                directories.push(relative);
+            }
         } else if metadata.is_file() {
             files.push(PackageFile {
                 path: relative,
@@ -1423,6 +1426,8 @@ mod tests {
         write_skill(&canonical_root, "audit", "audit v1");
 
         let target = canonical_root.join("audit");
+        let empty_directory = target.join("local-empty-directory");
+        fs::create_dir_all(&empty_directory).unwrap();
         let destination = input.home.join(".agents").join("skills").join("audit");
         fs::create_dir_all(destination.parent().unwrap()).unwrap();
         if !make_dir_symlink(&target, &destination) {
@@ -1451,6 +1456,7 @@ mod tests {
             .is_symlink());
         assert_eq!(fs::read(destination.join("SKILL.md")).unwrap(), b"audit v1");
         assert_eq!(package_digest_at(&target).unwrap(), target_digest);
+        assert!(empty_directory.is_dir());
         assert_eq!(
             inspect_codex_skills(&input).unwrap().statuses[0].state,
             CodexSkillState::Healthy

--- a/engine/crates/legion-host/src/legacy_claude.rs
+++ b/engine/crates/legion-host/src/legacy_claude.rs
@@ -711,7 +711,7 @@ fn inspect_plugin_cache(
                 && legion_plugin_manifest
                 && skills_root
                     .as_deref()
-                    .is_some_and(|path| content_tree_matches(path, canonical_skills_root));
+                    .is_some_and(|path| content_tree_contains(path, canonical_skills_root));
             let available_skill_ids = skills_root
                 .as_deref()
                 .map(|root| {
@@ -751,11 +751,34 @@ fn string_field(record: &serde_json::Map<String, Value>, field: &str) -> Option<
         .map(str::to_owned)
 }
 
-fn content_tree_matches(left: &Path, right: &Path) -> bool {
-    let Some(left_digest) = release_assets_digest(left) else {
+fn content_tree_contains(candidate: &Path, canonical: &Path) -> bool {
+    let mut candidate_files = BTreeMap::new();
+    let mut candidate_remaining = MAX_TREE_ENTRIES;
+    if collect_release_files(
+        candidate,
+        Path::new(""),
+        &mut candidate_files,
+        &mut candidate_remaining,
+    )
+    .is_none()
+    {
         return false;
-    };
-    release_assets_digest(right).as_deref() == Some(left_digest.as_str())
+    }
+    let mut canonical_files = BTreeMap::new();
+    let mut canonical_remaining = MAX_TREE_ENTRIES;
+    if collect_release_files(
+        canonical,
+        Path::new(""),
+        &mut canonical_files,
+        &mut canonical_remaining,
+    )
+    .is_none()
+    {
+        return false;
+    }
+    canonical_files
+        .iter()
+        .all(|(path, bytes)| candidate_files.get(path) == Some(bytes))
 }
 
 fn is_legion_plugin_id(id: &str) -> bool {
@@ -1326,6 +1349,12 @@ mod tests {
         )
         .unwrap();
         write_skill(&cache.join("skills"), "audit", "current audit");
+        fs::create_dir_all(cache.join("skills").join("audit").join("scripts")).unwrap();
+        fs::write(
+            cache.join("skills").join("audit").join("scripts/helper.py"),
+            "print('plugin-only helper')",
+        )
+        .unwrap();
         let cache_index = home
             .join(".claude")
             .join("plugins")

--- a/engine/crates/legion-host/src/legacy_claude.rs
+++ b/engine/crates/legion-host/src/legacy_claude.rs
@@ -707,9 +707,11 @@ fn inspect_plugin_cache(
                 .as_deref()
                 .is_some_and(has_legion_plugin_manifest);
             let canonical_generation = canonical_skills_root_trusted
+                && cache_managed
+                && legion_plugin_manifest
                 && skills_root
                     .as_deref()
-                    .is_some_and(|path| same_real_path(path, canonical_skills_root));
+                    .is_some_and(|path| content_tree_matches(path, canonical_skills_root));
             let available_skill_ids = skills_root
                 .as_deref()
                 .map(|root| {
@@ -747,6 +749,13 @@ fn string_field(record: &serde_json::Map<String, Value>, field: &str) -> Option<
         .and_then(Value::as_str)
         .filter(|value| !value.trim().is_empty())
         .map(str::to_owned)
+}
+
+fn content_tree_matches(left: &Path, right: &Path) -> bool {
+    let Some(left_digest) = release_assets_digest(left) else {
+        return false;
+    };
+    release_assets_digest(right).as_deref() == Some(left_digest.as_str())
 }
 
 fn is_legion_plugin_id(id: &str) -> bool {
@@ -1289,6 +1298,59 @@ mod tests {
         assert!(standalone.join("blueprint").exists());
         assert_eq!(fs::read(&cache_path).unwrap(), cache);
         assert!(repair.plugin_cache_untouched);
+    }
+
+    #[test]
+    fn current_claude_cache_copy_is_canonical_generation() {
+        let temp = TempRoot::new("current-cache-generation");
+        let home = temp.0.join("home");
+        let canonical = temp
+            .0
+            .join("release")
+            .join("share")
+            .join("legion")
+            .join("assets")
+            .join("skills");
+        write_skill(&canonical, "audit", "current audit");
+        let cache = home
+            .join(".claude")
+            .join("plugins")
+            .join("cache")
+            .join("orthic-labs")
+            .join("legion")
+            .join("0.1.0");
+        fs::create_dir_all(cache.join(".claude-plugin")).unwrap();
+        fs::write(
+            cache.join(".claude-plugin").join("plugin.json"),
+            r#"{"name":"legion","version":"0.1.0"}"#,
+        )
+        .unwrap();
+        write_skill(&cache.join("skills"), "audit", "current audit");
+        let cache_index = home
+            .join(".claude")
+            .join("plugins")
+            .join("installed_plugins.json");
+        fs::write(
+            &cache_index,
+            serde_json::to_vec(&json!({
+                "plugins": {
+                    "legion@orthic-labs": [{
+                        "version": "0.1.0",
+                        "installPath": cache,
+                    }]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let inspection = inspect_claude_legacy(&input(&home, &canonical, &["audit"])).unwrap();
+        assert_eq!(inspection.plugin_cache_generations.len(), 1);
+        assert!(inspection.plugin_cache_generations[0].canonical_generation);
+        assert!(inspection
+            .remediation
+            .iter()
+            .all(|item| !item.contains("non-canonical Legion plugin cache generation")));
     }
 
     #[test]

--- a/engine/crates/legion-runtime/src/release_binding.rs
+++ b/engine/crates/legion-runtime/src/release_binding.rs
@@ -521,16 +521,20 @@ fn digest(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static NEXT_ROOT: AtomicU64 = AtomicU64::new(0);
 
     fn root() -> PathBuf {
         let root = std::env::temp_dir().join(format!(
-            "legion-binding-{}-{}",
+            "legion-binding-{}-{}-{}",
             std::process::id(),
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .expect("clock")
-                .as_nanos()
+                .as_nanos(),
+            NEXT_ROOT.fetch_add(1, Ordering::Relaxed)
         ));
         fs::create_dir_all(root.join("assets/nested")).expect("directory");
         fs::write(root.join("runtime"), b"runtime").expect("runtime");

--- a/right-release.config.mjs
+++ b/right-release.config.mjs
@@ -47,7 +47,7 @@ export default {
 	schema: 1,
 	app: "legion",
 	hostedWorkflows: "right-git-ci-only",
-	version: "release/version.json",
+	version: releaseVersion,
 	packageManager: "pnpm@11.24.0",
 	workdir: ".",
 	checks: ["legion:check", "test"],

--- a/scripts/assemble-native-release.mjs
+++ b/scripts/assemble-native-release.mjs
@@ -123,18 +123,14 @@ function writeJson(path, value) {
 	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-const LEGACY_RUNTIME_EXTENSIONS = new Set([
-	".cjs",
-	".js",
-	".mjs",
-	".py",
-	".pyc",
-]);
+function excludedSkillArtifact(path) {
+	const segments = path.toLowerCase().split("/");
+	return segments.includes("__pycache__") || path.toLowerCase().endsWith(".pyc");
+}
 
-function copyDeclarativeTree(source, destination) {
+function copySkillTree(source, destination) {
 	for (const path of filesBelow(source).sort()) {
-		const extension = path.slice(path.lastIndexOf(".")).toLowerCase();
-		if (LEGACY_RUNTIME_EXTENSIONS.has(extension)) continue;
+		if (excludedSkillArtifact(path)) continue;
 		const target = join(destination, path);
 		mkdirSync(dirname(target), { recursive: true });
 		copyFileSync(join(source, path), target);
@@ -256,7 +252,7 @@ copyFileSync(
 	join(repositoryRoot, "src", "registry", "skills", "index.json"),
 	catalogPath,
 );
-copyDeclarativeTree(join(repositoryRoot, "skills"), join(assets, "skills"));
+copySkillTree(join(repositoryRoot, "skills"), join(assets, "skills"));
 
 const mcpToolSchema = {
 	schemaVersion: 1,

--- a/tests/release-artifacts.test.mjs
+++ b/tests/release-artifacts.test.mjs
@@ -77,6 +77,7 @@ test('verifyReleaseManifest rejects missing required artifacts', () => {
 test('right-release config keeps signing and publication fail-closed', () => {
   const config = readReleaseConfig();
   assert.match(config, /hostedWorkflows: "right-git-ci-only"/);
+  assert.match(config, /version: releaseVersion/);
   assert.match(config, /signed: true/);
   assert.match(config, /publishBlocked/);
   assert.match(config, /signedProvenanceScheme: "rightkit-release"/);

--- a/tests/release-artifacts.test.mjs
+++ b/tests/release-artifacts.test.mjs
@@ -88,6 +88,14 @@ test('right-release config keeps signing and publication fail-closed', () => {
   assert.doesNotMatch(config, /files:\s*\[/);
 });
 
+test('native skill assembly retains runtime helpers and excludes generated Python cache', () => {
+  const assembly = readFile(new URL('../scripts/assemble-native-release.mjs', import.meta.url), 'utf8');
+  assert.match(assembly, /function copySkillTree/);
+  assert.match(assembly, /segments\.includes\("__pycache__"\)/);
+  assert.match(assembly, /endsWith\("\.pyc"\)/);
+  assert.doesNotMatch(assembly, /LEGACY_RUNTIME_EXTENSIONS/);
+});
+
 test('Windows package binds target identity and emits blocked evidence seams', () => {
   const repositoryRoot = mkdtempSync(join(tmpdir(), 'legion-win-package-'));
   const input = join(repositoryRoot, 'assembled');


### PR DESCRIPTION
Fixes native setup's false stale classification after a valid same-version Claude plugin reinstall. Canonical cache identity now requires trusted installed-release skills, Claude-managed cache ownership, a Legion manifest, & exact content-tree equality. Adds focused regression coverage.