### PR TITLE
test: make m1 temp roots collision-proof

### DIFF
--- a/engine/crates/legion-application/src/lib.rs
+++ b/engine/crates/legion-application/src/lib.rs
@@ -1918,17 +1918,24 @@ mod m1_tests {
         collections::BTreeSet,
         fs,
         path::{Path, PathBuf},
+        sync::atomic::{AtomicU64, Ordering},
         time::{SystemTime, UNIX_EPOCH},
     };
 
     fn temp_root() -> PathBuf {
+        // Tests in this module run concurrently in one process, and coarse
+        // SystemTime ticks (notably on macOS) let two of them draw the same
+        // pid+nanos name — the first cleanup then deletes the other test's
+        // fixtures mid-run. The counter makes every root unique.
+        static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
         let root = std::env::temp_dir().join(format!(
-            "legion-m1-application-{}-{}",
+            "legion-m1-application-{}-{}-{}",
             std::process::id(),
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .expect("clock")
-                .as_nanos()
+                .as_nanos(),
+            TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed),
         ));
         fs::create_dir_all(root.join("registry")).expect("registry directory");
         root

--- a/src/packages/arcane/lib/receipt-store.mjs
+++ b/src/packages/arcane/lib/receipt-store.mjs
@@ -128,7 +128,7 @@ export class ReceiptStore {
       } catch (err) {
         throw new ArcaneError('ARC_STORE_CORRUPT', 'cannot append: last stored entry is unreadable', {
           sequence: lines.length,
-          parseError: String(err && err.message),
+          parseError: String(err?.message),
         });
       }
       prevDigest = digestValue(lastEntry);


### PR DESCRIPTION
m1_tests run concurrently in one process, and coarse SystemTime ticks (notably macOS) let two tests draw the same pid+nanos temp directory name; the first cleanup then deleted the other test's fixtures mid-run, failing fs reads with NotFound (release-candidate run 33209597664, macos-15 job). A process-wide atomic counter makes every root unique. Verified: m1_tests pass 6/6 consecutive local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)