### PR TITLE
perf(build): cap dev-profile debuginfo at line tables

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -58,3 +58,7 @@ windows-sys = { version = "0.61.2", features = [
     "Win32_System_Threading",
 ] }
 tiktoken-rs = "0.12.0"
+
+[profile.dev]
+# line-tables-only: full debuginfo dominates large-crate dev codegen; backtraces keep file:line
+debug = "line-tables-only"


### PR DESCRIPTION
Full debuginfo (debug=2) dominated large-crate dev/test codegen and inflated sccache entries workspace-wide. Line tables keep file:line in backtraces; variable-level debugger info is a dev-profile-only loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)